### PR TITLE
[BLUEMOON] Custom clothing examine text

### DIFF
--- a/modular_bluemoon/code/modules/clothing/clothing.dm
+++ b/modular_bluemoon/code/modules/clothing/clothing.dm
@@ -1,0 +1,31 @@
+/obj/item/clothing
+	/**
+	 * Всплывающая подсказка с дополнительным описанием у имени при осмотре.
+	 * Вторая переменная является флагом очистки подсказки при снятии предмета.
+	 */
+	var/list/custom_examine_tooltip = list("", TRUE)
+
+/obj/item/clothing/verb/set_custom_examine_text()
+	set name = "Set custom examine text"
+	set category = "Object"
+	set src in view(0)
+
+	if(!(isliving(usr) || iscyborg(usr) || isanimal(usr)))
+		return
+	if(item_flags & ABSTRACT)
+		return
+	var/usrinput = stripped_input(usr, "Какое у предмета будет дополнительное описание при осмотре? Cancel - очистить.", "Дополнительное описание", custom_examine_tooltip[1], MAX_NAME_LEN)
+	custom_examine_tooltip[1] = usrinput
+	usrinput = alert(usr, "Оставить описание даже после снятия предмета?", "Постоянное описание", "Да", "Нет")
+	custom_examine_tooltip[2] = (usrinput == "Да") ? FALSE : TRUE
+
+/obj/item/clothing/get_examine_name(mob/user)
+	. = ..()
+	if(custom_examine_tooltip[1])
+		. += " <span class='chat-tooltip green bold'>\[+\]<span class='chat-tooltip__content'>[custom_examine_tooltip[1]]</span></span>"
+
+/obj/item/clothing/dropped(mob/user)
+	. = ..()
+	if(custom_examine_tooltip[1] && custom_examine_tooltip[2])
+		if(current_equipped_slot & slot_flags)
+			custom_examine_tooltip[1] = ""

--- a/modular_bluemoon/code/modules/clothing/clothing.dm
+++ b/modular_bluemoon/code/modules/clothing/clothing.dm
@@ -17,7 +17,6 @@
 	var/usrinput = stripped_input(usr, "Какое у предмета будет дополнительное описание при осмотре? Cancel - очистить.", "Дополнительное описание", custom_examine_tooltip[1], MAX_NAME_LEN)
 	custom_examine_tooltip[1] = usrinput
 	if(!usrinput)
-		custom_examine_tooltip[2] = TRUE
 		return
 	usrinput = alert(usr, "Оставить описание даже после снятия предмета?", "Постоянное описание", "Да", "Нет")
 	custom_examine_tooltip[2] = (usrinput == "Да") ? FALSE : TRUE

--- a/modular_bluemoon/code/modules/clothing/clothing.dm
+++ b/modular_bluemoon/code/modules/clothing/clothing.dm
@@ -24,7 +24,7 @@
 /obj/item/clothing/get_examine_name(mob/user)
 	. = ..()
 	if(custom_examine_tooltip[1])
-		. += " <span class='chat-tooltip green bold'>\[+\]<span class='chat-tooltip__content'>[custom_examine_tooltip[1]]</span></span>"
+		. = " <span class='chat-tooltip green bold'; style='text-decoration: underline dashed green;'>[.]<span class='chat-tooltip__content'>[custom_examine_tooltip[1]]</span></span>"
 
 /obj/item/clothing/dropped(mob/user)
 	. = ..()

--- a/modular_bluemoon/code/modules/clothing/clothing.dm
+++ b/modular_bluemoon/code/modules/clothing/clothing.dm
@@ -10,12 +10,15 @@
 	set category = "Object"
 	set src in view(0)
 
-	if(!(isliving(usr) || iscyborg(usr) || isanimal(usr)))
+	if(!isliving(usr))
 		return
 	if(item_flags & ABSTRACT)
 		return
 	var/usrinput = stripped_input(usr, "Какое у предмета будет дополнительное описание при осмотре? Cancel - очистить.", "Дополнительное описание", custom_examine_tooltip[1], MAX_NAME_LEN)
 	custom_examine_tooltip[1] = usrinput
+	if(!usrinput)
+		custom_examine_tooltip[2] = TRUE
+		return
 	usrinput = alert(usr, "Оставить описание даже после снятия предмета?", "Постоянное описание", "Да", "Нет")
 	custom_examine_tooltip[2] = (usrinput == "Да") ? FALSE : TRUE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4549,6 +4549,7 @@
 #include "modular_bluemoon\code\modules\client\loadout\uniform.dm"
 #include "modular_bluemoon\code\modules\client\loadout\wrists.dm"
 #include "modular_bluemoon\code\modules\clothing\assasin_suit.dm"
+#include "modular_bluemoon\code\modules\clothing\clothing.dm"
 #include "modular_bluemoon\code\modules\clothing\fancy_maid_costume.dm"
 #include "modular_bluemoon\code\modules\clothing\gloves.dm"
 #include "modular_bluemoon\code\modules\clothing\pact_ninja_suit.dm"


### PR DESCRIPTION
Теперь к одежде можно добавлять кастомный текст, который будет виден при осмотре персонажа, наведясь на контекстную подсказку. Менюшка открывается через ПКМ.

<img width="448" height="83" alt="3595379" src="https://github.com/user-attachments/assets/c4a10873-2a52-4fe3-88b7-cf752acded03" />

=================================================

<img width="486" height="271" alt="6804040" src="https://github.com/user-attachments/assets/ef9a00be-b63d-4423-8b6a-fa82436aa3f9" />

=================================================

<img width="473" height="268" alt="46704-4-848458" src="https://github.com/user-attachments/assets/4bbcd3b6-47e7-4f21-8252-c9fd7f641ecf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Добавлена возможность задавать пользовательские описания для предметов одежды, которые отображаются при осмотре.
  * Опция сохранять описание после снятия предмета или автоматически удалять его при снятии.
  * Описания отображаются рядом с названием предмета с улучшенным форматированием.
  * Доступ к созданию заметок ограничен живыми персонажами (включая киборгов/животных).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->