### PR TITLE
Убираем набор для кухни из контрабанды

### DIFF
--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -146,7 +146,6 @@
 	name = "Kitchen Cutlery Deluxe Set"
 	desc = "Нужно нарезать кубиками помидоры? Что ж, у нас есть то, что вам нужно! В комплекте хороший набор ножей, вилок, тарелок, стаканов и точильнй камень."
 	cost = 10000
-	contraband = TRUE
 	contains = list(/obj/item/sharpener, //Deluxe for a reason
 					/obj/item/kitchen/fork,
 					/obj/item/kitchen/fork,


### PR DESCRIPTION
# Описание

<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Почему у нас столовые приборы стали запрещёнными?

## Демонстрация изменений

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

:cl:
fix: перенёс заказ столовых приборов и точильного камня из контрабанды
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Набор "Кухонные приборы Deluxe" больше не помечен как контрабанда и теперь доступен для стандартного заказа в каталоге служебных поставок.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->