### PR TITLE
[BLUEMOON] Interactable items are highlighted in strip menu

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -376,6 +376,7 @@
 		result["icon"] = icon2base64(icon(item.icon, item.icon_state, SOUTH, 1))
 		result["name"] = item.name
 		result["alternate"] = item_data.get_alternate_action(owner, user)
+		result["interactable"] = item.interactable_in_strip_menu
 
 		items[strippable_key] = result
 

--- a/modular_bluemoon/code/game/objects/items.dm
+++ b/modular_bluemoon/code/game/objects/items.dm
@@ -1,4 +1,5 @@
 /obj/item
+	/// In hand items can be used on this item through mob strip menu. Check proc/use_item_on_strippable() for details.
 	var/interactable_in_strip_menu = FALSE
 
 /**
@@ -6,13 +7,14 @@
  * but instead of beginning unequipping selected item, stripper tries to use his in hand item on seleted item.
  * Only certain items can be interacted with while being worn by owner: set "interactable_in_strip_menu" flag.
  * Proc returns TRUE if held item can and will be used on worn item (attackby()).
+ *
+ * WARNING! We pretend wearer is using item to prevent errors. We adjust this proc to already existing mechanics.
  */
 /obj/item/proc/use_item_on_strippable(mob/stripper, mob/owner, obj/item/held_item)
 	. = TRUE
 	if(!istype(held_item))
 		return FALSE
 	if(!interactable_in_strip_menu)
-		// to_chat(stripper, span_warning("Selected item can not be interacted by in hand items while being worn."))
 		return FALSE
 	owner.visible_message(
 			span_warning("[stripper] is using [held_item] on [owner]'s [name]."),

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -536,7 +536,7 @@ export const StripMenu = (props, context) => {
                     tooltip = item.name;
                     if(item.interactable) {
                       interactable = item.interactable;
-                      tooltip = `${tooltip} (ITEMS INTERACTIONS)`;
+                      tooltip = `${tooltip} (CAN USE ITEMS ON IT)`;
                     }
                   } else if ("obscured" in item) {
                     content = (

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -449,6 +449,7 @@ type StripMenuItem =
           icon: string;
           name: string;
           alternate?: string;
+          interactable: boolean;
         }
       | {
           obscured: ObscuringLevel;
@@ -510,6 +511,7 @@ export const StripMenu = (props, context) => {
 
                   let content;
                   let tooltip;
+                  let interactable;
 
                   if (item === null) {
                     tooltip = slot.displayName;
@@ -532,6 +534,10 @@ export const StripMenu = (props, context) => {
                     );
 
                     tooltip = item.name;
+                    if(item.interactable) {
+                      interactable = item.interactable;
+                      tooltip = `${tooltip} (ITEMS INTERACTIONS)`;
+                    }
                   } else if ("obscured" in item) {
                     content = (
                       <Icon
@@ -580,7 +586,9 @@ export const StripMenu = (props, context) => {
                           style={{
                             background: item?.interacting
                               ? "hsl(39, 73%, 30%)"
-                              : undefined,
+                              : interactable
+                                ? "green"
+                                : undefined,
                             position: "relative",
                             width: "100%",
                             height: "100%",


### PR DESCRIPTION
Менюшка раздевания персонажа: если на одежду можно использовать предмет прямо через менюшку, то она подсвечивается + всплывающая подсказка.

<img width="614" height="450" alt="3578739037093" src="https://github.com/user-attachments/assets/e1b94153-124d-4442-9f76-dca6c721f7fb" />

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: Надетая на моба одежда подсвечиваются в менюшке раздевания, если на неё можно использовать предметы.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Меню раздевания теперь передаёт и показывает флаг взаимодействия для предметов: в подсказке появляется пометка о возможности использования предмета на носителе.
  * Предметы, с которыми можно взаимодействовать (и которые не заняты), выделяются зелёным фоном.

* **Документация**
  * Обновлены внутренние комментарии к поведению использования предметов в меню (информативные пояснения, без изменения API).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->