### PR TITLE
Чиним нерабочий ножик эшей

### DIFF
--- a/modular_bluemoon/code/modules/ashwalkers/code/effects/tendril_cursing.dm
+++ b/modular_bluemoon/code/modules/ashwalkers/code/effects/tendril_cursing.dm
@@ -1,0 +1,83 @@
+/obj/structure/spawner/lavaland
+	/// whether it has a curse attached to it
+	var/cursed = FALSE
+
+/obj/structure/spawner/lavaland/attackby(obj/item/attacking_item, mob/user, params)
+	if(istype(attacking_item, /obj/item/cursed_dagger))
+		playsound(get_turf(src), 'sound/effects/magic/demon_attack1.ogg', 50, TRUE)
+		cursed = !cursed
+		if(cursed)
+			src.add_atom_colour("#41007e", TEMPORARY_COLOUR_PRIORITY)
+		else
+			src.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#41007e")
+		balloon_alert_to_viewers("проклятие было [cursed ? "наложено..." : "снято..."]")
+		if(isliving(user))
+			var/mob/living/living_user = user
+			living_user.adjustFireLoss(100)
+		to_chat(user, span_warning("Нож обжигает вашу руку!"))
+		return
+	return ..()
+
+/obj/structure/spawner/lavaland/Destroy()
+	if(cursed)
+		for(var/mob/living/carbon/human/selected_human in range(7))
+			if(is_species(selected_human, /datum/species/lizard/ashwalker))
+				continue
+			selected_human.AddComponent(/datum/component/ash_cursed)
+		for(var/mob/select_mob in GLOB.player_list)
+			if(!is_species(select_mob, /datum/species/lizard/ashwalker))
+				continue
+			to_chat(select_mob, span_boldwarning("Проклятый тендрил был сломан! Цель будет оставлять следы до тех пор, пока она не покинет эти земли!"))
+	. = ..()
+
+/datum/component/ash_cursed
+	/// the person who is targeted by the curse
+	var/mob/living/carbon/human/human_target
+
+/datum/component/ash_cursed/Initialize()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	human_target = parent
+	ADD_TRAIT(human_target, TRAIT_NO_TELEPORT, REF(src))
+	human_target.add_movespeed_modifier(/datum/movespeed_modifier/ash_cursed)
+	RegisterSignal(human_target, COMSIG_MOVABLE_MOVED, PROC_REF(do_move))
+	RegisterSignal(human_target, COMSIG_LIVING_DEATH, PROC_REF(remove_curse))
+
+/datum/component/ash_cursed/Destroy(force, silent)
+	. = ..()
+	REMOVE_TRAIT(human_target, TRAIT_NO_TELEPORT, REF(src))
+	human_target.remove_movespeed_modifier(/datum/movespeed_modifier/ash_cursed)
+	UnregisterSignal(human_target, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_DEATH))
+	human_target = null
+
+/datum/component/ash_cursed/proc/remove_curse()
+	SIGNAL_HANDLER
+	for(var/mob/select_mob in GLOB.player_list)
+		if(!is_species(select_mob, /datum/species/lizard/ashwalker))
+			continue
+		to_chat(select_mob, span_boldwarning("Цель мертва, проклятие снято!"))
+	Destroy()
+
+/datum/component/ash_cursed/proc/do_move()
+	SIGNAL_HANDLER
+	var/turf/human_turf = get_turf(human_target)
+	if(!is_mining_level(human_turf.z))
+		Destroy()
+		for(var/mob/select_mob in GLOB.player_list)
+			if(!is_species(select_mob, /datum/species/lizard/ashwalker))
+				continue
+			to_chat(select_mob, span_boldwarning("Цель сбежала с Лаваленда, уничтожив проклятие!"))
+		return
+	if(prob(75))
+		return
+	var/obj/effect/decal/cleanable/greenglow/ecto/spawned_goo = locate() in human_turf
+	if(spawned_goo)
+		return
+	spawned_goo = new(human_turf)
+	addtimer(CALLBACK(spawned_goo, TYPE_PROC_REF(/obj/effect/decal/cleanable/greenglow/ecto, do_qdel)), 5 MINUTES, TIMER_STOPPABLE|TIMER_DELETE_ME)
+
+/obj/effect/decal/cleanable/greenglow/ecto/proc/do_qdel()
+	qdel(src)
+
+/datum/movespeed_modifier/ash_cursed
+	multiplicative_slowdown = 1.0

--- a/modular_bluemoon/code/modules/ashwalkers/code/effects/tendril_cursing.dm
+++ b/modular_bluemoon/code/modules/ashwalkers/code/effects/tendril_cursing.dm
@@ -61,6 +61,8 @@
 /datum/component/ash_cursed/proc/do_move()
 	SIGNAL_HANDLER
 	var/turf/human_turf = get_turf(human_target)
+	if(!human_turf)
+		return
 	if(!is_mining_level(human_turf.z))
 		Destroy()
 		for(var/mob/select_mob in GLOB.player_list)


### PR DESCRIPTION
# Описание

Перенес файл с ВМа без которого он не работал.
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [x] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Потому что баг.

## Демонстрация изменений

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: починил cursed ash dagger, теперь, если им ударить тендрил, то человеку, что ударил нанесётся 100 ожогов, а тендрил пометится. Если сломать помеченный тендрил, то будет накладываться замедление и оставлять следы в виде зелёной слизи
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Добавлена механика «проклятых щупалец» в Лавалэнде: структуры можно проклясть специальным кинжалом — слышен звук и спрайт меняется.
  * Разрушение проклятой структуры накладывает проклятие на nearby людей: блокировка телепортации, сильное замедление и предупреждение игроку.
  * Проклятые цели оставляют зелёный светящийся след на земле, который держится несколько минут; проклятие снимается при смерти цели или покидании уровня Лаваленда.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->