### PR TITLE
Изменение инструкций локализации

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -73,8 +73,8 @@ reviews:
         === LOCALIZATION ===
         - English is expected and correct for: name, technical terms, programming references, Linux command parodies, chemical names, and game mechanic strings
         - Do NOT suggest translating these to Russian — they follow SS13 conventions
-        - Translate all other user-facing text to Russian
-				- Flag any English text in user-facing chat messages, UI labels, or other player-visible text that is not covered by the exceptions above
+        - All player-visible text should be in Russian unless covered by the exceptions above.
+        - Flag any English text in user-facing chat messages, UI labels, or other player-visible text that is not covered by the exceptions above
 
         === GARBAGE COLLECTION ===
         - Always use qdel(obj) to delete objects, NEVER use del(obj) or del obj

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -71,7 +71,7 @@ reviews:
         - No getter procs — access variables directly or use macros
 
         === LOCALIZATION ===
-        - English is expected and correct for: name, technical terms, programming references, Linux command parodies, chemical names, and game mechanic strings
+        - English is expected and correct for: name, technical terms, programming references, Linux command parodies, chemical names
         - Do NOT suggest translating these to Russian — they follow SS13 conventions
         - All player-visible text should be in Russian unless covered by the exceptions above.
         - Flag any English text in user-facing chat messages, UI labels, or other player-visible text that is not covered by the exceptions above

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -66,16 +66,15 @@ reviews:
         - Initialize() instead of New() for atoms
         - Time defines (SECONDS, MINUTES, HOURS) not raw deciseconds
         - Signal handlers must start with SIGNAL_HANDLER
-
-        === LOCALIZATION ===
-        - English is expected and correct for: name, desc, and other in-game object identifiers
-        - Technical terms, programming references, Linux command parodies, chemical names, and game mechanic strings are fine in English
-        - Do NOT suggest translating these to Russian — they follow SS13 conventions
-        - Only flag English text in user-facing chat messages or UI labels that should be localized
-        - CALLBACK() macro for deferred execution
         - for(var/type/name as anything in list) when list type is known
         - SHOULD_CALL_PARENT(TRUE) on root procs with signals
         - No getter procs — access variables directly or use macros
+
+        === LOCALIZATION ===
+        - English is expected and correct for: name, technical terms, programming references, Linux command parodies, chemical names, and game mechanic strings
+        - Do NOT suggest translating these to Russian — they follow SS13 conventions
+        - Translate all other user-facing text to Russian
+				- Flag any English text in user-facing chat messages, UI labels, or other player-visible text that is not covered by the exceptions above
 
         === GARBAGE COLLECTION ===
         - Always use qdel(obj) to delete objects, NEVER use del(obj) or del obj

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -128,7 +128,10 @@ reviews:
         - useLocalState setter triggers synchronous re-render — NEVER call during render body (causes infinite loop crash)
         - DM uses 32-bit floats — values from act() lose precision above ~7 significant digits
         - User-facing UI labels, descriptions, and messages should be in Russian
-        - English is acceptable for: item/object names from DM (name, desc), technical terms, abbreviations, programming references, and game mechanic identifiers — do not flag these
+        - English is expected and correct for: name, technical terms, programming references, Linux command parodies, chemical names
+        - Do NOT suggest translating these to Russian — they follow SS13 conventions
+        - All player-visible text should be in Russian unless covered by the exceptions above.
+        - Flag any English text in user-facing chat messages, UI labels, or other player-visible text that is not covered by the exceptions above
     - path: "modular_bluemoon/**"
       instructions: |
         BlueMoon-specific modular content. Preferred location for new custom features.


### PR DESCRIPTION
# Описание

Меняем инструкции для Coderabbit, насчёт локализации, так как там указана не актуальная информация. Теперь он будет переводить всё, кроме: "name, technical terms, programming references, Linux command parodies, chemical names". Также чуть рефакторим инструкции, так как одна повторяет другую, более подробную, а остальные находятся не в том разделе.

## Причина изменений

Актуализация

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Документация**
  * Обновлены правила проверки текстов на локализацию и стиль для файлов сценариев.
  * Уточнены требования к английскому и русскому языкам в видимых игроку сообщениях, включая чат и интерфейс.
  * Перенесены и переразмечены некоторые стилевые рекомендации для более понятной структуры правил.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->