### PR TITLE
[BLUEMOON] Force naked flavor and pics

### DIFF
--- a/code/datums/character_profile.dm
+++ b/code/datums/character_profile.dm
@@ -1,5 +1,10 @@
 /mob/living/carbon/human
 	var/datum/description_profile/profile
+	/**
+	 * Отображение описания и изображений оголенного тела персонажа в окне осмотра вне зависимости от наличия закрывающей одежды. Переключается через панельку.
+	 * Не сохраняется в настройках игрока, т.к. задумывается как временное состояние для конкретных ЕРП ситуаций, не требующее переноса между раундами.
+	 */
+	var/force_naked_flavor = FALSE
 
 /mob/living/silicon/robot
 	var/datum/description_profile/robot/profile
@@ -135,21 +140,22 @@ GLOBAL_LIST_EMPTY(cached_previews)
 		if (istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = C
 			var/can_see_naked = TRUE
-			var/list/obj/item/clothings = list(
-				H.wear_suit,
-				H.w_uniform,
-				H.belt,
-				H.w_underwear,
-				H.w_socks,
-				H.w_shirt,
-				H.wrists,
-				H.wear_neck
-			)
-			removeNullsFromList(clothings)
-			for (var/obj/item/clothing/clothpiece in clothings)
-				if(clothpiece.body_parts_covered & GROIN || clothpiece.body_parts_covered & CHEST)
-					can_see_naked = FALSE
-					break
+			if(!H.force_naked_flavor)
+				var/list/obj/item/clothings = list(
+					H.wear_suit,
+					H.w_uniform,
+					H.belt,
+					H.w_underwear,
+					H.w_socks,
+					H.w_shirt,
+					H.wrists,
+					H.wear_neck
+				)
+				removeNullsFromList(clothings)
+				for (var/obj/item/clothing/clothpiece in clothings)
+					if(clothpiece.body_parts_covered & GROIN || clothpiece.body_parts_covered & CHEST)
+						can_see_naked = FALSE
+						break
 			data["flavortext_naked"] = can_see_naked ? (C.dna?.naked_flavor_text || "") : ""
 			data["headshot_naked_links"] =  (check_rights_for(user.client, R_ADMIN) && isobserver(user)) || ((!unknown) && can_see_naked) ? (C.dna.headshot_naked_links.Copy() || "") : list()
 	// BLUEMOON EDIT END

--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -884,9 +884,11 @@
 			if(ishuman(parent_mob))
 				var/mob/living/carbon/human/H = parent_mob
 				H.force_naked_flavor = !H.force_naked_flavor
+				if(H.force_naked_flavor)
+					H.balloon_alert_to_viewers("Доступно описание голого тела")
 				return TRUE
 			else
-				to_chat(parent_mob, span_warning("Unavailable for non-human mob."))
+				to_chat(parent_mob, span_warning("Unavailable for non-humanoid mob."))
 				return FALSE
 
 #undef INTERACTION_UNHOLY //SPLURT Edit

--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -141,6 +141,11 @@
 	.["selfAttributes"] = self.list_interaction_attributes(self)
 	.["lust"] = self.get_lust()
 	.["maxLust"] = self.get_climax_threshold() // BLUEMOON EDIT
+	if(ishuman(self))
+		var/mob/living/carbon/human/H = self
+		.["force_naked_flavor"] = H.force_naked_flavor
+	else
+		.["force_naked_flavor"] = null
 
 	.["max_distance"] = 0
 	.["user_is_blacklisted"] = SSinteractions.is_blacklisted(self)
@@ -875,5 +880,13 @@
 					else
 						to_chat(parent_mob, span_warning("Unavailable for this mob."))
 						return FALSE
+		if("force_naked_flavor")
+			if(ishuman(parent_mob))
+				var/mob/living/carbon/human/H = parent_mob
+				H.force_naked_flavor = !H.force_naked_flavor
+				return TRUE
+			else
+				to_chat(parent_mob, span_warning("Unavailable for non-human mob."))
+				return FALSE
 
 #undef INTERACTION_UNHOLY //SPLURT Edit

--- a/tgui/packages/tgui/interfaces/MobInteraction/tabs/GenitalTab.tsx
+++ b/tgui/packages/tgui/interfaces/MobInteraction/tabs/GenitalTab.tsx
@@ -7,6 +7,7 @@ import { Button, Flex, Section, Stack } from '../../../components';
 
 type GenitalInfo = {
   genitals: GenitalData[];
+  force_naked_flavor: boolean;
 }
 
 type GenitalData = {
@@ -26,8 +27,20 @@ export const GenitalTab = (props, context) => {
     setSearchText,
   ] = useLocalState(context, 'searchText', '');
   const genitals = sortGenitals(data.genitals, searchText) || [];
+  const force_naked_flavor = data.force_naked_flavor;
   return (
     <Section>
+      {(force_naked_flavor !== null && (
+        <Button
+          fluid
+          mb={1}
+          content="Force naked flavor"
+          icon={force_naked_flavor ? "toggle-on" : "toggle-off"}
+          selected={force_naked_flavor}
+          tooltip={`Отображение описания и изображений оголенного тела персонажа в окне осмотра вне зависимости от наличия закрывающей одежды`}
+          onClick={() => act('force_naked_flavor')}
+        />
+      ))}
       {genitals.length ? (
         <Flex direction="column">
           {genitals.map(genital => (


### PR DESCRIPTION
В панельку добавлена кнопка отображения описания и изображений оголенного тела персонажа в окне осмотра вне зависимости от наличия закрывающей одежды.

На практике используется в тех случаях, когда закрывающая одежда остается на персонаже, но все интересующие части тела оголены.

Сделал отдельно через кнопочку, а не в зависимости от видимости отдельных органов, т.к. это дает игроку точечный контроль над представлением своего персонажа.

<img width="426" height="109" alt="3603680360" src="https://github.com/user-attachments/assets/a985b810-264f-4cf5-a193-d8e9780794ef" />

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: В панельку добавлена кнопка вывода флавора и картинок оголенного тела персонажа в окне осмотра, игнорируя носимую одежду.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * В окне взаимодействия для персонажей-человеков добавлена кнопка переключения режима отображения «naked flavor».
  * При включении режим может показывать описание и изображения тела в осмотре независимо от одежды.

* **Bug Fixes**
  * Улучшено поведение отображения в интерфейсе осмотра: теперь состояние режима корректно переключается и отображается для подходящих персонажей.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->