### PR TITLE
[BLUEMOON] Clipping condoms

### DIFF
--- a/code/__DEFINES/_flags/obj_flags.dm
+++ b/code/__DEFINES/_flags/obj_flags.dm
@@ -22,6 +22,8 @@
 #define ITEM_HAS_CONTEXTUAL_SCREENTIPS 		(1<<19)					/// Has contextual screentips when HOVERING OVER OTHER objects
 #define BLOCKS_CONSTRUCTION 				(1<<20) 				//! Does this object prevent things from being built on it?
 #define BLOCKS_CONSTRUCTION_DIR 			(1<<21)					//! Does this object prevent same-direction things from being built on it?
+#define NOT_VISIBLE_IN_STORAGE				(1<<22) 				// Предмет не отображается в контейнерах, вместилищах объектов (/datum/component/storage) при осмотре игроком.
+
 
 /// Integrity defines for clothing (not flags but close enough)
 #define CLOTHING_PRISTINE	0 // We have no damage on the clothing

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -183,6 +183,13 @@
 					contents.Cut(1, limited_random_access_stack_position + 1)
 				else
 					contents.Cut(1, length(contents) - limited_random_access_stack_position + 1)
+		var/obj/o
+		for(var/i = contents.len to 1 step -1)
+			o = contents[i]
+			if(!istype(o))
+				continue
+			if(o.obj_flags & NOT_VISIBLE_IN_STORAGE)
+				contents.Cut(i,i+1)
 	return contents
 
 /datum/component/storage/proc/canreach_react(datum/source, list/next)

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -26,7 +26,9 @@
 	var/max_accessories = 7 // BLUEMOON EDIT - расширено возможное количество аксессуаров с 3 до 7
 	var/max_restricted_accessories = 3 // BLUEMOON ADD - максимальное количество особых (боевых) аксессуаров
 	var/list/obj/item/clothing/accessory/attached_accessories = list()
-	var/list/mutable_appearance/accessory_overlays = list()
+	// Отдельно 2 типа оверлея: один применяется на униформу, второй - на спрайт моба. Хранить нужно оба и отдельно.
+	var/list/mutable_appearance/accessory_uniform_overlays = list()
+	var/list/mutable_appearance/accessory_mob_overlays = list()
 	//SANDSTORM EDIT END
 
 /obj/item/clothing/under/worn_overlays(isinhands = FALSE, icon_file, used_state, style_flags = NONE)
@@ -37,8 +39,8 @@
 		. += mutable_appearance('icons/effects/item_damage.dmi', "damageduniform")
 	if(blood_DNA)
 		. += mutable_appearance('icons/effects/blood.dmi', "uniformblood", color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
-	if(length(accessory_overlays))
-		. += accessory_overlays
+	if(length(accessory_mob_overlays))
+		. += accessory_mob_overlays
 
 /obj/item/clothing/under/attackby(obj/item/I, mob/user, params)
 	if((sensordamage || (has_sensor < HAS_SENSORS && has_sensor != NO_SENSORS)) && istype(I, /obj/item/stack/cable_coil))
@@ -210,29 +212,17 @@
 				to_chat(user, "<span class='warning'>[src] слишком громоздкое, к нему нельзя крепить аксессуары!</span>")
 			return
 		else
-			if(user && !user.temporarilyRemoveItemFromInventory(I))
+			if(user && !user.temporarilyRemoveItemFromInventory(A))
 				return
 			if(!A.attach(src, user))
+				A.forceMove(drop_location()) // user.put_in_hands() вызывает где-то у себя в глубине stoplag(), что не нравится Initialize()
 				return
 
 			if(user && notifyAttach)
-				to_chat(user, "<span class='notice'>Вы прикрепили [I] к [src].</span>")
+				to_chat(user, "<span class='notice'>Вы прикрепили [A] к [src].</span>")
 
 			if((flags_inv & HIDEACCESSORY) || (A.flags_inv & HIDEACCESSORY))
 				return TRUE
-
-			//SANDSTORM EDIT
-			accessory_overlays = list(mutable_appearance('icons/mob/clothing/accessories.dmi', "blank"))
-			for(var/obj/item/clothing/accessory/attached_accessory in attached_accessories)
-				var/datum/element/polychromic/polychromic = LAZYACCESS(attached_accessory.comp_lookup, "item_worn_overlays")
-				if(!polychromic)
-					var/mutable_appearance/accessory_overlay = mutable_appearance(attached_accessory.mob_overlay_icon, attached_accessory.item_state || attached_accessory.icon_state, -UNIFORM_LAYER)
-					accessory_overlay.alpha = attached_accessory.alpha
-					accessory_overlay.color = attached_accessory.color
-					accessory_overlays += accessory_overlay
-				else
-					polychromic.apply_worn_overlays(attached_accessory, FALSE, attached_accessory.mob_overlay_icon, attached_accessory.item_state || attached_accessory.icon_state, NONE, accessory_overlays)
-			//SANDSTORM EDIT END
 
 			if(ishuman(loc))
 				var/mob/living/carbon/human/H = loc
@@ -390,7 +380,7 @@
 
 /obj/item/clothing/under/AltClick(mob/user)
 	. = ..()
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user), TRUE, FALSE))
+	if(. || !istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user), TRUE, FALSE))
 		return
 	if(length(attached_accessories)) //SKYRAT EDIT
 		remove_accessory(user)

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -36,7 +36,8 @@
 /obj/item/clothing/accessory/proc/attach(obj/item/clothing/under/U, user)
 	var/datum/component/storage/storage = GetComponent(/datum/component/storage)
 	if(storage)
-		if(SEND_SIGNAL(U, COMSIG_CONTAINS_STORAGE))
+		// if(SEND_SIGNAL(U, COMSIG_CONTAINS_STORAGE)) - не работает. Parent меняется, но сигналы не реагируют.
+		if(U.GetComponent(/datum/component/storage))
 			return FALSE
 		U.TakeComponent(storage)
 		detached_pockets = storage
@@ -76,55 +77,47 @@
 	if(isliving(user))
 		on_uniform_dropped(U, user)
 
-	if(minimize_when_attached)
-		transform *= 2
-		pixel_x = 0
-		pixel_y = 0
-	layer = initial(layer)
-	plane = initial(plane)
-	U.cut_overlays()
+	U.cut_overlay(U.accessory_uniform_overlays)
+	U.accessory_uniform_overlays = list()
+	U.accessory_mob_overlays = list()
 	U.attached_accessories -= src
-	U.accessory_overlays = list()
-	if(length(U.attached_accessories))
-		U.accessory_overlays = list(mutable_appearance('icons/mob/clothing/accessories.dmi', "blank"))
-		for(var/obj/item/clothing/accessory/attached_accessory in U.attached_accessories)
-			attached_accessory.force_unto(U)
-			var/datum/element/polychromic/polychromic = LAZYACCESS(attached_accessory.comp_lookup, "item_worn_overlays")
-			if(!polychromic)
-				var/mutable_appearance/accessory_overlay = mutable_appearance(attached_accessory.mob_overlay_icon, attached_accessory.item_state || attached_accessory.icon_state, -UNIFORM_LAYER)
-				accessory_overlay.alpha = attached_accessory.alpha
-				accessory_overlay.color = attached_accessory.color
-				U.accessory_overlays += accessory_overlay
-			else
-				polychromic.apply_worn_overlays(attached_accessory, FALSE, attached_accessory.mob_overlay_icon, attached_accessory.item_state || attached_accessory.icon_state, NONE, U.accessory_overlays)
+	for(var/obj/item/clothing/accessory/attached_accessory in U.attached_accessories)
+		attached_accessory.force_unto(U)
 
-//SANDSTORM EDIT
+/// Обработка наложений для униформы и для спрайта моба
 /obj/item/clothing/accessory/proc/force_unto(obj/item/clothing/under/U)
-	layer = FLOAT_LAYER
-	plane = FLOAT_PLANE
+	// Для униформы
+	var/mutable_appearance/accessory_overlay = new /mutable_appearance(src)
+	accessory_overlay.layer = FLOAT_LAYER
+	accessory_overlay.plane = FLOAT_PLANE
 	if(minimize_when_attached)
-		if(current_uniform != U)
-			transform *= 0.5	//halve the size so it doesn't overpower the under
-			pixel_x += 8
-			pixel_y -= 8
+		accessory_overlay.transform *= 0.5	//halve the size so it doesn't overpower the under
+		accessory_overlay.pixel_x += 8
+		accessory_overlay.pixel_y -= 8
 		if(length(U.attached_accessories) > 1)
 			if(length(U.attached_accessories) <= 3 && !current_uniform)
-				pixel_y += 8 * (length(U.attached_accessories) - 1)
+				accessory_overlay.pixel_y += 8 * (length(U.attached_accessories) - 1)
 			else if((length(U.attached_accessories) > 3) && (length(U.attached_accessories) <= 6) && !current_uniform)
-				pixel_x -= 8
-				pixel_y += 8 * (length(U.attached_accessories) - 4)
+				accessory_overlay.pixel_x -= 8
+				accessory_overlay.pixel_y += 8 * (length(U.attached_accessories) - 4)
 			else if((length(U.attached_accessories) > 6) && (length(U.attached_accessories) <= 9) && !current_uniform)
-				pixel_x -= 16
-				pixel_y += 8 * (length(U.attached_accessories) - 7)
+				accessory_overlay.pixel_x -= 16
+				accessory_overlay.pixel_y += 8 * (length(U.attached_accessories) - 7)
 			else
 				if(current_uniform != U)
 					//we ran out of space for accessories, so we just throw shit at the wall
-					pixel_x = 0
-					pixel_y = 0
-					pixel_x += rand(-16, 16)
-					pixel_y += rand(-16, 16)
-	U.add_overlay(src)
-//SANDSTORM EDIT END
+					accessory_overlay.pixel_x = 0
+					accessory_overlay.pixel_y = 0
+					accessory_overlay.pixel_x += rand(-16, 16)
+					accessory_overlay.pixel_y += rand(-16, 16)
+	U.accessory_uniform_overlays += accessory_overlay
+	U.add_overlay(accessory_overlay)
+	// Для спрайта моба
+	if(isemptylist(U.accessory_mob_overlays)) // без понятия зачем конретно это надо, такой алгоритм был до меня.
+		U.accessory_mob_overlays = list(mutable_appearance('icons/mob/clothing/accessories.dmi', "blank"))
+	var/datum/element/polychromic/polychromic = LAZYACCESS(comp_lookup, "item_worn_overlays")
+	polychromic?.apply_worn_overlays(src, FALSE, mob_overlay_icon, item_state || icon_state, NONE, U.accessory_mob_overlays)
+	U.accessory_mob_overlays += mutable_appearance(mob_overlay_icon, item_state || icon_state, -UNIFORM_LAYER, alpha = src.alpha, color = src.color)
 
 /obj/item/clothing/accessory/proc/on_uniform_equip(obj/item/clothing/under/U, user)
 	return

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -184,45 +184,10 @@
 	item_state = "gear_harness"
 	can_adjust = TRUE
 	body_parts_covered = CHEST|GROIN
-	var/filled_condoms_counter = 0
-
-/obj/item/clothing/under/misc/gear_harness/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = AddComponent(/datum/component/storage/concrete)
-	STR.max_w_class = WEIGHT_CLASS_TINY
-	STR.max_combined_w_class = WEIGHT_CLASS_TINY*100
-	STR.max_items = 100
-	STR.can_hold = typecacheof(list(/obj/item/genital_equipment/condom))
-	STR.insert_preposition = "on"
-	STR.display_numerical_stacking = TRUE
-	STR.click_gather = TRUE
-	STR.allow_quick_empty = TRUE
 
 /obj/item/clothing/under/misc/gear_harness/examine(mob/user)
 	. = ..()
-	. += "You can clip condoms onto it."
 	. += "<b>Alt-Click</b> to adjust coverage of your body."
-	if(filled_condoms_counter > 1)
-		. += "There are <b>[filled_condoms_counter]</b> filled condoms clipped onto it."
-	else if(filled_condoms_counter == 1)
-		. += "There is <b>[filled_condoms_counter]</b> filled condom clipped onto it."
-
-/obj/item/clothing/under/misc/gear_harness/get_examine_string(mob/user, thats)
-	. = ..()
-	if(filled_condoms_counter)
-		. += " with <span class='love'>[filled_condoms_counter] filled condom[filled_condoms_counter > 1 ? "s" : ""]</span> clipped onto it"
-
-/obj/item/clothing/under/misc/gear_harness/Entered(atom/movable/AM, atom/oldLoc)
-	. = ..()
-	var/obj/item/genital_equipment/condom/C = AM
-	if(C.reagents?.total_volume >= 1)
-		filled_condoms_counter++
-
-/obj/item/clothing/under/misc/gear_harness/Exited(atom/movable/AM, atom/newLoc)
-	. = ..()
-	var/obj/item/genital_equipment/condom/C = AM
-	if(C.reagents?.total_volume >= 1)
-		filled_condoms_counter--
 
 /obj/item/clothing/under/misc/gear_harness/toggle_jumpsuit_adjust()
 	if(!body_parts_covered)

--- a/modular_bluemoon/code/datums/components/condom_clipping.dm
+++ b/modular_bluemoon/code/datums/components/condom_clipping.dm
@@ -1,0 +1,84 @@
+/datum/component/condom_clipping
+	var/attached_condoms = 0
+	var/max_attached_condoms = 50 // остановимся на юбилейном числе
+	var/mutable_appearance/condom_overlay = null
+
+/datum/component/condom_clipping/Initialize()
+	if(!isclothing(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/condom_clipping/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(clip_condom))
+
+/datum/component/condom_clipping/UnregisterFromParent()
+	. = ..()
+	UnregisterSignal(parent, COMSIG_PARENT_ATTACKBY)
+
+/datum/component/condom_clipping/proc/clip_condom(datum/source, obj/item/genital_equipment/condom/condom, mob/living/user, mob/living/wearer)
+	SIGNAL_HANDLER
+	. = TRUE
+	var/obj/item/clothing/C = parent
+	if(source != C || !istype(condom) || !istype(user) || !user.canUseTopic(C, BE_CLOSE, ismonkey(user), NO_TK, FALSE))
+		return FALSE
+	if(attached_condoms >= max_attached_condoms)
+		to_chat(user, span_warning("Уже некуда цеплять использованные презервативы..."))
+		return FALSE
+	if(condom.reagents?.total_volume > 0)
+		if(user.transferItemToLoc(condom, C))
+			attached_condoms++
+			if((C.current_equipped_slot & C.slot_flags) && (user == wearer || C.loc == user))
+				user.visible_message(span_love("[user] нацепляет использованный презерватив себе на [C.name]."))
+			else
+				user.visible_message(span_love("[user] нацепляет использованный презерватив на [C.name][istype(wearer) ? " на [wearer]" : ""]."))
+		else
+			to_chat(user, span_warning("Не удалось прицепить презерватив."))
+			return FALSE
+	else
+		to_chat(user, span_warning("Прежде чем нацеплять презерватив на одежду, его необходимо использовать по назначению."))
+		return FALSE
+	if(attached_condoms == 1)
+		condom_overlay = new /mutable_appearance(condom)
+		condom_overlay.layer = -UNIFORM_LAYER
+		condom_overlay.transform *= 0.5
+		condom_overlay.pixel_x = 8
+		condom_overlay.pixel_y = 8
+		C.add_overlay(condom_overlay)
+
+/datum/component/condom_clipping/proc/unclip_condom(mob/living/user)
+	. = TRUE
+	if(attached_condoms <= 0 || !istype(user) || !user.canUseTopic(parent, BE_CLOSE, ismonkey(user), NO_TK, FALSE))
+		return FALSE
+	var/obj/item/clothing/C = parent
+	user.put_in_hands(locate(/obj/item/genital_equipment/condom) in C.contents)
+	attached_condoms--
+	if((C.current_equipped_slot & C.slot_flags) && ismob(C.loc))
+		user.visible_message("[user] снимает использованный презерватив с [C.name] на [user == C.loc ? "себе" : C.loc].")
+	else
+		user.visible_message("[user] снимает использованный презерватив с [C.name].")
+	if(attached_condoms <= 0)
+		C.cut_overlay(condom_overlay)
+		QDEL_NULL(condom_overlay)
+
+//Я не буду отдельно просматривать тысячу типов одежды на ирл возможность зацепления использованных презервативов, все остается на совести игроков.
+//Все остальное отыгрывается через пкм - custom examine text.
+
+/obj/item/clothing/under/Initialize(mapload)
+	. = ..()
+	if(!GetComponent(/datum/component/storage)) // не собираюсь мудохаться с контейнерами.
+		AddComponent(/datum/component/condom_clipping)
+
+/obj/item/clothing/underwear/briefs/Initialize(mapload)
+	. = ..()
+	if(!GetComponent(/datum/component/storage))
+		AddComponent(/datum/component/condom_clipping)
+
+/obj/item/clothing/underwear/shirt/Initialize(mapload)
+	. = ..()
+	if(!GetComponent(/datum/component/storage))
+		AddComponent(/datum/component/condom_clipping)
+
+/obj/item/clothing/underwear/chastity_belt/Initialize(mapload)
+	. = ..()
+	if(!GetComponent(/datum/component/storage))
+		AddComponent(/datum/component/condom_clipping)

--- a/modular_bluemoon/code/datums/components/condom_clipping.dm
+++ b/modular_bluemoon/code/datums/components/condom_clipping.dm
@@ -10,10 +10,30 @@
 /datum/component/condom_clipping/RegisterWithParent()
 	. = ..()
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(clip_condom))
+	// обработка через сингалы более громоздка, но безопаснее в целом и в особенности при взаимодействии с контейнерами
+	RegisterSignal(parent, COMSIG_ATOM_ENTERED, PROC_REF(plus_condom))
+	RegisterSignal(parent, COMSIG_ATOM_EXITED, PROC_REF(minus_condom))
 
 /datum/component/condom_clipping/UnregisterFromParent()
 	. = ..()
-	UnregisterSignal(parent, COMSIG_PARENT_ATTACKBY)
+	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_ATOM_ENTERED, COMSIG_ATOM_EXITED))
+	QDEL_NULL(condom_overlay)
+
+/datum/component/condom_clipping/proc/update_parent_overlays(obj/item/genital_equipment/condom/condom = /obj/item/genital_equipment/condom/open/used)
+	var/obj/item/clothing/C = parent
+	if(!istype(C))
+		CRASH("condom_clipping component has been assigned to incompatable atom for some reason.")
+	switch(attached_condoms)
+		if(1)
+			condom_overlay = new /mutable_appearance(condom)
+			condom_overlay.layer = -UNIFORM_LAYER
+			condom_overlay.transform *= 0.5
+			condom_overlay.pixel_x = 8
+			condom_overlay.pixel_y = 8
+			C.add_overlay(condom_overlay)
+		if(-INFINITY to 0)
+			C.cut_overlay(condom_overlay)
+			QDEL_NULL(condom_overlay)
 
 /datum/component/condom_clipping/proc/clip_condom(datum/source, obj/item/genital_equipment/condom/condom, mob/living/user, mob/living/wearer)
 	SIGNAL_HANDLER
@@ -26,7 +46,6 @@
 		return FALSE
 	if(condom.reagents?.total_volume > 0)
 		if(user.transferItemToLoc(condom, C))
-			attached_condoms++
 			if((C.current_equipped_slot & C.slot_flags) && (user == wearer || C.loc == user))
 				user.visible_message(span_love("[user] нацепляет использованный презерватив себе на [C.name]."))
 			else
@@ -37,48 +56,56 @@
 	else
 		to_chat(user, span_warning("Прежде чем нацеплять презерватив на одежду, его необходимо использовать по назначению."))
 		return FALSE
-	if(attached_condoms == 1)
-		condom_overlay = new /mutable_appearance(condom)
-		condom_overlay.layer = -UNIFORM_LAYER
-		condom_overlay.transform *= 0.5
-		condom_overlay.pixel_x = 8
-		condom_overlay.pixel_y = 8
-		C.add_overlay(condom_overlay)
+
+/datum/component/condom_clipping/proc/plus_condom(datum/source, obj/item/genital_equipment/condom/condom, atom/oldLoc)
+	SIGNAL_HANDLER
+	if(!istype(condom))
+		return
+	attached_condoms++
+	condom.obj_flags |= NOT_VISIBLE_IN_STORAGE
+	var/datum/component/storage/s = source.GetComponent(/datum/component/storage)
+	s?.refresh_mob_views()
+	update_parent_overlays(condom)
 
 /datum/component/condom_clipping/proc/unclip_condom(mob/living/user)
 	. = TRUE
 	if(attached_condoms <= 0 || !istype(user) || !user.canUseTopic(parent, BE_CLOSE, ismonkey(user), NO_TK, FALSE))
 		return FALSE
 	var/obj/item/clothing/C = parent
-	user.put_in_hands(locate(/obj/item/genital_equipment/condom) in C.contents)
-	attached_condoms--
-	if((C.current_equipped_slot & C.slot_flags) && ismob(C.loc))
-		user.visible_message("[user] снимает использованный презерватив с [C.name] на [user == C.loc ? "себе" : C.loc].")
+	var/obj/item/genital_equipment/condom/to_unclip = locate(/obj/item/genital_equipment/condom) in C.contents
+	if(to_unclip)
+		user.put_in_hands(to_unclip)
+		if((C.current_equipped_slot & C.slot_flags) && ismob(C.loc))
+			user.visible_message("[user] снимает использованный презерватив с [C.name] на [user == C.loc ? "себе" : C.loc].")
+		else
+			user.visible_message("[user] снимает использованный презерватив с [C.name].")
 	else
-		user.visible_message("[user] снимает использованный презерватив с [C.name].")
-	if(attached_condoms <= 0)
-		C.cut_overlay(condom_overlay)
-		QDEL_NULL(condom_overlay)
+		attached_condoms = 0
+		update_parent_overlays()
 
-//Я не буду отдельно просматривать тысячу типов одежды на ирл возможность зацепления использованных презервативов, все остается на совести игроков.
-//Все остальное отыгрывается через пкм - custom examine text.
+/datum/component/condom_clipping/proc/minus_condom(datum/source, obj/item/genital_equipment/condom/condom, atom/newLoc)
+	SIGNAL_HANDLER
+	if(!istype(condom))
+		return
+	attached_condoms--
+	condom.obj_flags &= ~NOT_VISIBLE_IN_STORAGE
+	update_parent_overlays(condom)
 
-/obj/item/clothing/under/Initialize(mapload)
+// Я не буду отдельно просматривать тысячу типов одежды на ирл возможность зацепления использованных презервативов, все остается на совести игроков.
+// Все остальное отыгрывается через пкм - custom examine text.
+
+/obj/item/clothing/under/ComponentInitialize(mapload)
 	. = ..()
-	if(!GetComponent(/datum/component/storage)) // не собираюсь мудохаться с контейнерами.
-		AddComponent(/datum/component/condom_clipping)
+	AddComponent(/datum/component/condom_clipping)
 
-/obj/item/clothing/underwear/briefs/Initialize(mapload)
+/obj/item/clothing/underwear/briefs/ComponentInitialize(mapload)
 	. = ..()
-	if(!GetComponent(/datum/component/storage))
-		AddComponent(/datum/component/condom_clipping)
+	AddComponent(/datum/component/condom_clipping)
 
-/obj/item/clothing/underwear/shirt/Initialize(mapload)
+/obj/item/clothing/underwear/shirt/ComponentInitialize(mapload)
 	. = ..()
-	if(!GetComponent(/datum/component/storage))
-		AddComponent(/datum/component/condom_clipping)
+	AddComponent(/datum/component/condom_clipping)
 
-/obj/item/clothing/underwear/chastity_belt/Initialize(mapload)
+/obj/item/clothing/underwear/chastity_belt/ComponentInitialize(mapload)
 	. = ..()
-	if(!GetComponent(/datum/component/storage))
-		AddComponent(/datum/component/condom_clipping)
+	AddComponent(/datum/component/condom_clipping)

--- a/modular_bluemoon/code/datums/components/condom_clipping.dm
+++ b/modular_bluemoon/code/datums/components/condom_clipping.dm
@@ -25,6 +25,8 @@
 		CRASH("condom_clipping component has been assigned to incompatable atom for some reason.")
 	switch(attached_condoms)
 		if(1)
+			if(istype(condom_overlay))
+				return
 			condom_overlay = new /mutable_appearance(condom)
 			condom_overlay.layer = -UNIFORM_LAYER
 			condom_overlay.transform *= 0.5

--- a/modular_bluemoon/code/modules/clothing/clothing.dm
+++ b/modular_bluemoon/code/modules/clothing/clothing.dm
@@ -31,3 +31,19 @@
 	if(custom_examine_tooltip[1] && custom_examine_tooltip[2])
 		if(current_equipped_slot & slot_flags)
 			custom_examine_tooltip[1] = ""
+
+/obj/item/clothing/AltClick(mob/user)
+	. = ..()
+	if(istype(src, /obj/item/clothing/under))
+		var/obj/item/clothing/under/U = src
+		if(length(U.attached_accessories))
+			return // аксессуары снимаются в приоритете
+	var/datum/component/condom_clipping/cc = GetComponent(/datum/component/condom_clipping)
+	if(cc?.unclip_condom(user))
+		return TRUE
+
+/obj/item/clothing/get_examine_string(mob/user, thats)
+	. = ..()
+	var/datum/component/condom_clipping/cc = GetComponent(/datum/component/condom_clipping)
+	if(cc?.attached_condoms)
+		. +=  " with <span bold class='love'><b>[cc.attached_condoms]</b> filled condom[cc.attached_condoms > 1 ? "s" : ""] attached onto it</span>"

--- a/modular_sand/code/modules/clothing/gloves/_gloves.dm
+++ b/modular_sand/code/modules/clothing/gloves/_gloves.dm
@@ -2,7 +2,8 @@
 	var/dummy_thick = FALSE // is able to hold accessories on its item
 	var/max_accessories = 1
 	var/list/obj/item/clothing/accessory/ring/attached_accessories = list() //BLUEMOON FIX не трогаем листы, без них потом на перчатки ничего не нацепить
-	var/list/mutable_appearance/accessory_overlays = list() //BLUEMOON FIX без этого рантаймит при попытке снять кольцо (юзаем систему униформы для перчаток)
+	var/list/mutable_appearance/accessory_uniform_overlays = list() //BLUEMOON FIX без этого рантаймит при попытке снять кольцо (юзаем систему униформы для перчаток)
+	var/list/mutable_appearance/accessory_mob_overlays = list() // за подробностями в _under.dm
 
 /obj/item/clothing/gloves/Destroy()
 	QDEL_LIST(attached_accessories)

--- a/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/condom.dm
+++ b/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/condom.dm
@@ -84,6 +84,37 @@
 	to_chat(user, "<span class='notice'>You unwrap the condom.</span>")
 	playsound(user, 'sound/items/poster_ripped.ogg', 50, 1, -1)
 
+/obj/item/genital_equipment/condom/attack(mob/living/M, mob/living/user, attackchain_flags, damage_multiplier)
+	if(!reagents.total_volume)
+		return
+	var/list/obscured_slots = M.check_obscured_slots()
+	var/list/available_clothing = list()
+	var/datum/component/condom_clipping/cc = null
+	for(var/obj/item/clothing/C in M.get_contents())
+		cc = C.GetComponent(/datum/component/condom_clipping)
+		if(!istype(cc))
+			continue
+		if(C.item_flags & ABSTRACT || C.obj_flags & EXAMINE_SKIP)
+			continue
+		if(!(C.current_equipped_slot & C.slot_flags))
+			continue
+		if(C.current_equipped_slot in obscured_slots)
+			continue
+		available_clothing[C] = new /mutable_appearance(C)
+	if(isemptylist(available_clothing))
+		to_chat(user, span_warning("Не найдено подходящей одежды."))
+		return
+	var/obj/item/clothing/choice = show_radial_menu(user, M, available_clothing, require_near = TRUE, tooltips = TRUE)
+	if(!istype(choice) || QDELETED(src) || QDELETED(choice) || QDELETED(user) || QDELETED(M))
+		return
+	if(M != user)
+		M.visible_message("[user] пытается нацепить использованный презерватив на [choice.name] на [M].", \
+						span_userdanger("[user] пытается нацепить использованный презерватив тебе на [choice.name]."))
+		if(!do_after(user, 5 SECONDS, choice, progress_loc = user))
+			return
+	cc = choice.GetComponent(/datum/component/condom_clipping)
+	cc.clip_condom(choice, src, user, M)
+
 /obj/item/genital_equipment/condom/throw_impact(atom/hit_atom)
 	. = ..()
 	if(!. && reagents.total_volume) //if we're not being caught

--- a/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/condom.dm
+++ b/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/condom.dm
@@ -112,6 +112,8 @@
 						span_userdanger("[user] пытается нацепить использованный презерватив тебе на [choice.name]."))
 		if(!do_after(user, 5 SECONDS, choice, progress_loc = user))
 			return
+		if(QDELETED(src) || QDELETED(M))
+			return
 	cc = choice.GetComponent(/datum/component/condom_clipping)
 	cc.clip_condom(choice, src, user, M)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4379,6 +4379,7 @@
 #include "modular_bluemoon\code\datums\world_topic.dm"
 #include "modular_bluemoon\code\datums\ai_laws\glados.dm"
 #include "modular_bluemoon\code\datums\brain_damage\imaginary_friend.dm"
+#include "modular_bluemoon\code\datums\components\condom_clipping.dm"
 #include "modular_bluemoon\code\datums\components\demoraliser.dm"
 #include "modular_bluemoon\code\datums\components\follow_component.dm"
 #include "modular_bluemoon\code\datums\components\latex_lockable.dm"


### PR DESCRIPTION
На одежду (свою или чужую) и нижнее белье можно нацеплять использованные презервативы. Они отображаются при осмотре персонажа. Также были исправлены некоторые баги одежды при взаимодействии с аксуссуарами, рефактор кода.

В список доступных для взаимодействия вещей входит большинство видов одежды, так как сидеть разгребать сотни хаотично разбросанных неструктурированных типов одежды излишне непродуктивно. Благоразумное приненение визуально-описательного рп функционала исключительно на совести игроков сервера.

Тестмерж на неделю.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: На бОльшую часть одежды и нижнего белья можно нацеплять использованные презервативы на обозрение всем.
fix: Исправлено исчезновение оверлея крови с одежды при взаимодействии с аксессуарами.
fix: Исправлена пропажа внутреннего инвентаря некоторых аксессуаров.
refactor: Рефактор функций обработки оверлеев аксессуаров, улучшение читаемости и оптимизация алгоритмов.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Добавлена логика крепления/снятия аксессуаров на части одежды с обновлённой отрисовкой на персонаже и самой вещи.
  - Применение использованных презервативов на совместимой одежде и снятие обратно через Alt-Click.
- **Bug Fixes**
  - При неудачном прикреплении аксессуары теперь корректно возвращаются в мир.
  - Осмотр одежды точнее показывает наличие аксессуаров и прикреплённых презервативов.
  - Предметы с флагом “не отображается в хранилищах” пропускаются в выдаче доступного содержимого.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->