### PR TITLE
Удаляем повторный щит

### DIFF
--- a/modular_bluemoon/fluffs/code/guns.dm
+++ b/modular_bluemoon/fluffs/code/guns.dm
@@ -1640,21 +1640,3 @@
 	var/fill_level = round(magazine.stored_ammo.len / magazine.max_ammo * 6)
 	if(fill_level < 6)
 		. += "pulsar-[fill_level]"
-
-/obj/item/modkit/lapkee_arm_shield_kit
-	name = "Holographic shield Kit"
-	desc = "A modkit for making a arm-mounted riot shield into a Holographic shield."
-	product = /obj/item/organ/cyberimp/arm/shield/sec_level/lapkee
-	fromitem = list(/obj/item/organ/cyberimp/arm/shield/sec_level)
-
-/obj/item/organ/cyberimp/arm/shield/sec_level/lapkee
-	name = "Arm-mounted holographic shield"
-	contents = newlist(/obj/item/shield/riot/implant/lapkee)
-
-/obj/item/shield/riot/implant/lapkee
-	name = "Holographic shield"
-	icon = 'modular_bluemoon/fluffs/icons/obj/melee.dmi'
-	icon_state = "lapkee_riot_shield"
-	item_state = "lapkee_riot_shield"
-	lefthand_file = 'modular_bluemoon/fluffs/icons/mob/inhands/melee_lefthand.dmi'
-	righthand_file = 'modular_bluemoon/fluffs/icons/mob/inhands/melee_righthand.dmi'


### PR DESCRIPTION
# Описание

Вышло так, что я забыл сохранить файл guns.dm и щит из него не удалился. Выходит у нас два одинаковых кода, но в разных файлах
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Чтобы ничего не сломалось


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Удалено**
  * Убран модкит для установки импланта-щита.
  * Удалён соответствующий имплант и связанный с ним голографический щит.
  * Предметы больше недоступны для получения и использования в игре.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->