### PR TITLE
[BLUEMOON] Full spaceproof prisoner transport bag

### DIFF
--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -2033,6 +2033,9 @@
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "dA" = (
+/obj/item/bodybag/containment/prisoner,
+/obj/item/bodybag/containment/prisoner,
+/obj/item/bodybag/containment/prisoner,
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "dB" = (

--- a/_maps/shuttles/slaveship_basic.dmm
+++ b/_maps/shuttles/slaveship_basic.dmm
@@ -401,6 +401,12 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plating,
 /area/shuttle/slaveship)
+"No" = (
+/obj/item/bodybag/containment/prisoner,
+/obj/item/bodybag/containment/prisoner,
+/obj/item/bodybag/containment/prisoner,
+/turf/open/floor/plating/rust,
+/area/shuttle/slaveship)
 "NN" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium,
@@ -754,7 +760,7 @@ yT
 yT
 Wk
 aN
-rc
+No
 Iu
 ax
 "}

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -159,6 +159,7 @@
 		ADD_TRAIT(AM, TRAIT_RESISTLOWPRESSURE, REF(src))
 		ADD_TRAIT(AM, TRAIT_RESISTHEAT, REF(src))
 		ADD_TRAIT(AM, TRAIT_RESISTCOLD, REF(src))
+		ADD_TRAIT(AM, TRAIT_NOBREATH, REF(src))
 
 /obj/structure/closet/body_bag/containment/prisoner/Exited(atom/movable/AM, atom/newLoc)
 	. = ..()


### PR DESCRIPTION
Мешки для транспортировки заключенных не требуют дополнительных махинаций для обеспечения выживания жертвы. Мешок полностью гермитичный и обеспечивает выживание заключенного в открытом космосе. Такие были добавлены на шаттлы пиратов и слейверов.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: Мешки для транспортировки заключенных полностью защищают существ от космоса.
map: Мешки для транспортировки заключенных добавлены на шаттлы пиратов и слейверов.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
  - На шаттлах добавлены дополнительные контейнеры для перевозки заключённых.
  - На базовом рабском шаттле появился отдельный участок с контейнерами и металлическим полом.

- **Исправления**
  - Находящиеся внутри контейнера живые существа теперь не теряют воздух во время перевозки.
  - После выхода из контейнера связанные эффекты корректно снимаются.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->