### PR TITLE
Фикс минорных багов и система линковки модулей

### DIFF
--- a/code/modules/mod/_mod_defines.dm
+++ b/code/modules/mod/_mod_defines.dm
@@ -5,10 +5,8 @@
 // #define MOD_PART_CORE		5
 #define MOD_PART_CELL 		5
 
-#define MOD_STATE_RETRACTED  1
-#define MOD_STATE_DEPLOYING  2
-#define MOD_STATE_DEPLOYED   3
-#define MOD_STATE_RETRACTING 4
+#define MODPART_DEPLOYED  "deployed"
+#define MODPART_CONSEALED "consealed"
 
 #define MOD_HELMET mod_parts[MOD_PART_HEAD]
 #define MOD_CHESTPLATE mod_parts[MOD_PART_CHEST]

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -56,6 +56,7 @@
 	if(wearer.equip_to_slot_if_possible(piece, piece.slot_flags, qdel_on_fail = FALSE, disable_warning = TRUE))
 		ADD_TRAIT(piece, TRAIT_NODROP, MOD_TRAIT)
 		if(!user)
+			piece.toggle_all_linked_modules(MODPART_DEPLOYED)
 			return TRUE
 		wearer.visible_message(span_notice("[wearer]'s [piece] deploy[piece.p_s()] with a mechanical hiss."),
 			span_notice("[piece] разворачивается[piece.p_s()] с механическим шипением."),
@@ -65,6 +66,7 @@
 			wearer.equip_to_slot_if_possible(item_in_slot, ITEM_SLOT_SUITSTORE)
 		if(need_to_conseal && is_active() && all_parts_deployed())
 			update_hardlight()
+		piece.toggle_all_linked_modules(MODPART_DEPLOYED)
 		return TRUE
 	else if(piece.loc != src)
 		if(!user)
@@ -88,6 +90,7 @@
 		span_notice("[piece] retract[piece.p_s()] back into [src] with a mechanical hiss."),
 		span_hear("You hear a mechanical hiss."))
 	remove_hardlight()
+	piece.toggle_all_linked_modules(MODPART_CONSEALED)
 	playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 /obj/item/mod/control/proc/toggle_activate(mob/user, force_deactivate = FALSE)

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -73,8 +73,11 @@
 	if(!item)
 		return TRUE
 	overslot = item
-	if(item.type in overslot_blacklist)
-		return FALSE
+
+	for(var/type in overslot_blacklist)
+		if(istype(item, type))
+			return FALSE
+
 	return mod.wearer.transferItemToLoc(overslot, item, force = TRUE)
 
 /obj/item/clothing/mod_part/proc/seal_part(seal)

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -18,6 +18,7 @@
 		/obj/item/clothing/head/helmet,
 		//Сюда вписываем то, поверх чего должно быть невозможно развернуть элемент МОДа!
 	)
+	var/obj/item/mod/module/linked_modules = list()
 	var/theme_category
 
 /obj/item/clothing/mod_part/equipped(mob/user, slot)
@@ -33,6 +34,30 @@
 		return
 	mod.conceal(null, item)
 	mod.remove_hardlight()
+
+/obj/item/clothing/mod_part/proc/link_modpart_with_module(module)
+	if(istype(module, /obj/item/mod/module) && (module in linked_modules))
+		return FALSE
+	linked_modules += module
+	return TRUE
+
+/obj/item/clothing/mod_part/proc/toggle_all_linked_modules(state)
+	if(!linked_modules)
+		return FALSE
+
+	if(state == MODPART_CONSEALED)
+		for(var/obj/item/mod/module/module in linked_modules)
+			module.saved_state = module.active
+			module.on_deactivation()
+			return TRUE
+	else
+		for(var/obj/item/mod/module/module in linked_modules)
+			if(!module.saved_state)
+				continue
+			module.on_activation()
+
+/obj/item/clothing/mod_part/proc/check_module_ready()
+	return mod.is_active() && mod.wearer.get_item_by_slot(src.slot_flags) == src
 
 /obj/item/clothing/mod_part/proc/update_flags(list/used_skin)
 	var/list/category = used_skin[theme_category]

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -49,7 +49,7 @@
 		for(var/obj/item/mod/module/module in linked_modules)
 			module.saved_state = module.active
 			module.on_deactivation()
-			return TRUE
+		return TRUE
 	else
 		for(var/obj/item/mod/module/module in linked_modules)
 			if(!module.saved_state)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -90,6 +90,11 @@
 /obj/item/mod/control/proc/get_boots()
 	return mod_parts[MOD_PART_FEET]
 
+//Проверяет, надет ли этот элемент одежды, а так же включён ли МОД
+/obj/item/mod/control/proc/check_module_ready_by_mod_index(mod_index)
+	var/obj/item/clothing/mod_part/part = get_mod_part_by_index(mod_index)
+	return part?.check_module_ready()
+
 /obj/item/mod/control/proc/all_parts_deployed()
 	if(!wearer)
 		return FALSE
@@ -219,7 +224,8 @@
 	return ..()
 
 /obj/item/mod/control/MouseDrop(atom/over_object)
-	if(src != wearer?.back || !istype(over_object, /atom/movable/screen/inventory/hand))
+	var/obj/item/target_object = wearer?.get_item_by_slot(src.slot_flags)
+	if(src != target_object || !istype(over_object, /atom/movable/screen/inventory/hand))
 		return ..()
 	if(is_active())
 		balloon_alert(wearer, "Отключите МОД!")
@@ -430,7 +436,7 @@
 	var/list/display_names = list()
 	var/list/items = list()
 	for(var/obj/item/mod/module/module as anything in modules)
-		if(module.module_type == MODULE_PASSIVE)
+		if(module.module_type == MODULE_PASSIVE || module.module_type == MODULE_ARMOR)
 			continue
 		display_names[module.name] = REF(module)
 		var/image/module_image = image(icon = module.icon, icon_state = module.icon_state)
@@ -447,10 +453,15 @@
 	selected_module.on_select()
 
 /obj/item/mod/control/proc/set_mod_color(new_color)
-	var/list/all_parts = mod_parts + src
-	for(var/obj/item/part as anything in all_parts)
+	var/list/all_parts = mod_parts
+	for(var/index in all_parts)
+		if(index == MOD_PART_CELL)
+			continue
+		var/obj/item/clothing/mod_part/part = all_parts[index]
 		part.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		part.add_atom_colour(new_color, FIXED_COLOUR_PRIORITY)
+	src.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+	src.add_atom_colour(new_color, FIXED_COLOUR_PRIORITY)
 	wearer?.regenerate_icons()
 
 /obj/item/mod/control/proc/set_mod_skin(new_skin)

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -50,6 +50,10 @@
 	var/my_retract_sound = 'sound/mecha/mechmove03.ogg'
 	///Быстрая ссылка на компонент втягиваемости
 	var/datum/component/mod_retractable/my_retract_component
+	var/obj/item/clothing/mod_part/required_modpart
+	var/required_modpart_index
+	var/startup_with_suit = FALSE
+	var/saved_state
 
 /obj/item/mod/module/Initialize(mapload)
 	. = ..()
@@ -73,9 +77,19 @@
 	if(user.hud_list[DIAG_HUD] && user.client.images & user.hud_list[DIAG_HUD])
 		. += span_notice("Использовано места: [complexity]")
 
+/obj/item/mod/module/proc/check_required_modpart()
+	if(!mod || !mod?.wearer)
+		return FALSE
+	if(!required_modpart)
+		return TRUE
+	return required_modpart.check_module_ready()
+
 /// Called from MODsuit's install() proc, so when the module is installed.
 /obj/item/mod/module/proc/on_install()
-	return
+	if(required_modpart_index)
+		required_modpart = mod.get_mod_part_by_index(required_modpart_index)
+		required_modpart?.link_modpart_with_module(src)
+		return
 
 /// Called from MODsuit's uninstall() proc, so when the module is uninstalled.
 /obj/item/mod/module/proc/on_uninstall()
@@ -83,7 +97,7 @@
 
 /// Called when the MODsuit is activated
 /obj/item/mod/module/proc/on_suit_activation()
-	return
+	return startup_with_suit ? on_activation() : FALSE
 
 /// Called when the MODsuit is deactivated
 /obj/item/mod/module/proc/on_suit_deactivation()
@@ -104,6 +118,9 @@
 	if(((!mod.is_active() || mod.is_activating()) && !allowed_inactive))
 		mod.balloon_alert(mod.wearer, "Сначала активируйте костюм!")
 		return
+	if(!check_required_modpart())
+		mod.balloon_alert(mod.wearer, "Выдвиньте [required_modpart.name]")
+		return
 	if(module_type != MODULE_USABLE)
 		if(active)
 			on_deactivation()
@@ -119,13 +136,16 @@
 	if(!COOLDOWN_FINISHED(src, cooldown_timer))
 		mod.balloon_alert(mod.wearer, "на перезарядке!")
 		return FALSE
-	if(!mod.is_active() || mod.is_activating() || !cell?.charge)
+	if(!mod.is_active() || !cell?.charge)
 		mod.balloon_alert(mod.wearer, "обесточен!")
 		return FALSE
 	if(!allowed_in_phaseout && istype(mod.wearer.loc, /obj/effect/dummy/phased_mob))
 		//specifically a to_chat because the user is phased out.
 		to_chat(mod.wearer, span_warning("Вы не можете активировать это сейчас!"))
 		return FALSE
+	if(!check_required_modpart())
+		mod.balloon_alert(mod.wearer, "Выдвиньте [required_modpart.name]")
+		return
 	if(module_type == MODULE_ACTIVE)
 		if(mod.selected_module && !mod.selected_module.on_deactivation())
 			return

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -93,6 +93,9 @@
 
 /// Called from MODsuit's uninstall() proc, so when the module is uninstalled.
 /obj/item/mod/module/proc/on_uninstall()
+	if(required_modpart)
+		required_modpart.linked_modules -= src
+		required_modpart = null
 	return
 
 /// Called when the MODsuit is activated

--- a/code/modules/mod/modules/modules.dm
+++ b/code/modules/mod/modules/modules.dm
@@ -18,7 +18,7 @@
 	REMOVE_TRAIT(mod.wearer, TRAIT_ANTIMAGIC, MOD_TRAIT)
 	REMOVE_TRAIT(mod.wearer, TRAIT_HOLY, MOD_TRAIT)
 
-/obj/item/mod/module/kinesis //TODO POST-MERGE MAKE NOT SUCK ASS, MAKE BALLER AS FUCK
+/obj/item/mod/module/kinesis
 	name = "MOD kinesis module"
 	desc = "Модульное дополнение к предплечью, этот модуль считался утерянным многие годы, \
 		nесмотря на то, что костюмы, на которые он раньше устанавливался, всё ещё встречаются. \
@@ -26,12 +26,9 @@
 		позволяя ему перемещать объекты — от титанового стержня до промышленного оборудования. \
 		Странно, но он, кажется, не работает на живых существах."
 	icon_state = "kinesis"
-//	module_type = MODULE_ACTIVE
 	module_type = MODULE_TOGGLE
-//	complexity = 3
-	complexity = 0
-	active_power_cost = DEFAULT_CHARGE_DRAIN*0.75
-//	use_power_cost = DEFAULT_CHARGE_DRAIN*3
+	complexity = 3
+	active_power_cost = DEFAULT_CHARGE_DRAIN*2
 	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/kinesis)
 	cooldown_time = 0.5 SECONDS

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -5,9 +5,12 @@
 	name = "infiltrator MOD module"
 	desc = "Скрывает ваше лицо от трекинга ИИ и чужих глаз, делая полностью неузнаваемым."
 	icon_state = "infiltrator"
+	module_type = MODULE_TOGGLE
 	complexity = 1
 	idle_power_cost = 0
 	removable = FALSE
+	required_modpart_index = MOD_PART_HEAD
+	startup_with_suit = TRUE
 
 /obj/item/mod/module/infiltrator/on_install()
 	. = ..()
@@ -19,18 +22,16 @@
 	var/obj/item/clothing/mod_part/head/head = mod.mod_parts[MOD_PART_HEAD]
 	head.blockTracking = FALSE
 
-/obj/item/mod/module/infiltrator/on_suit_activation()
+/obj/item/mod/module/infiltrator/on_activation()
 	. = ..()
-	if(!mod.wearer)
+	if(!mod.wearer || !.) //если родитель выдал FALSE
 		return
 	mod.wearer.infiltrator_active = TRUE
 	mod.wearer.set_bark("bump")
 	mod.wearer.digitalcamo = TRUE
 	mod.wearer.digitalinvis = TRUE
-	// var/list/need_to_conseal = list()
-	// wearer.apply_bodypart_overlays(need_to_conseal, update = TRUE, effect_datum = /datum/overlay_effect/mod_effect/white_noize)
 
-/obj/item/mod/module/infiltrator/on_suit_deactivation()
+/obj/item/mod/module/infiltrator/on_deactivation()
 	. = ..()
 	mod.wearer.infiltrator_active = FALSE
 	mod.wearer.set_bark(mod.wearer.client.prefs.bark_id)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -33,9 +33,10 @@
 	complexity = 1
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.5
 	incompatible_modules = list(/obj/item/mod/module/t_ray)
-	cooldown_time = 0.5 SECONDS
+	cooldown_time = 0.3 SECONDS
+	required_modpart_index = MOD_PART_HEAD
 	/// T-ray scan range.
-	var/range = 4
+	var/range = 8
 	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/t_ray/on_active_process(delta_time)
@@ -54,6 +55,7 @@
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.5
 	incompatible_modules = list(/obj/item/mod/module/magboot)
 	cooldown_time = 0.5 SECONDS
+	required_modpart_index = MOD_PART_FEET
 	/// Slowdown added onto the suit.
 	var/slowdown_active = 2
 	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
@@ -98,6 +100,7 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN
 	incompatible_modules = list(/obj/item/mod/module/tether)
 	cooldown_time = 1.5 SECONDS
+	required_modpart_index = MOD_PART_GLOVES
 	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/tether/on_use()
@@ -159,14 +162,20 @@
 /obj/item/mod/module/rad_protection/on_suit_activation()
 	mod.armor = mod.armor.modifyRating(rad = 65)
 	mod.rad_flags = RAD_PROTECT_CONTENTS|RAD_NO_CONTAMINATE
-	for(var/obj/item/part in mod.mod_parts)
+	for(var/index in mod.mod_parts)
+		if(index == MOD_PART_CELL)
+			continue
+		var/obj/item/clothing/mod_part/part = mod.mod_parts[index]
 		part.armor = mod.armor
 		part.rad_flags = mod.rad_flags
 
 /obj/item/mod/module/rad_protection/on_suit_deactivation(deleting = FALSE)
 	mod.armor = mod.armor.modifyRating(rad = -65)
 	mod.rad_flags = NONE
-	for(var/obj/item/part in mod.mod_parts)
+	for(var/index in mod.mod_parts)
+		if(index == MOD_PART_CELL)
+			continue
+		var/obj/item/clothing/mod_part/part = mod.mod_parts[index]
 		part.armor = mod.armor
 		part.rad_flags = mod.rad_flags
 
@@ -202,6 +211,7 @@
 	device = /obj/item/reagent_containers/spray/mister
 	incompatible_modules = list(/obj/item/mod/module/mister)
 	cooldown_time = 0.5 SECONDS
+	required_modpart_index = MOD_PART_GLOVES
 	/// Volume of our reagent holder.
 	var/volume = 500
 	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -326,6 +326,7 @@
 	/// Maximum range we can set.
 	var/max_range = 5
 	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
+	required_modpart_index = MOD_PART_HEAD
 
 /obj/item/mod/module/flashlight/on_activation()
 	. = ..()
@@ -393,6 +394,7 @@
 	/// Time it takes for us to dispense.
 	var/dispense_time = 0 SECONDS
 	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
+	required_modpart_index = MOD_PART_GLOVES
 
 /obj/item/mod/module/dispenser/on_use()
 	. = ..()

--- a/code/modules/mod/modules/modules_maint.dm
+++ b/code/modules/mod/modules/modules_maint.dm
@@ -19,6 +19,7 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 0.5
 	incompatible_modules = list(/obj/item/mod/module/balloon)
 	cooldown_time = 15 SECONDS
+	required_modpart_index = MOD_PART_GLOVES
 
 /obj/item/mod/module/balloon/on_use()
 	. = ..()
@@ -45,6 +46,7 @@
 	cooldown_time = 5 SECONDS
 	/// The total number of sheets created by this MOD. The more sheets, them more likely they set on fire.
 	var/num_sheets_dispensed = 0
+	required_modpart_index = MOD_PART_GLOVES
 
 /obj/item/mod/module/paper_dispenser/on_use()
 	. = ..()
@@ -88,6 +90,7 @@
 	device = /obj/item/stamp/mod
 	incompatible_modules = list(/obj/item/mod/module/stamp)
 	cooldown_time = 0.5 SECONDS
+	required_modpart_index = MOD_PART_GLOVES
 
 /obj/item/stamp/mod
 	name = "MOD electronic stamp"

--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -186,6 +186,7 @@
 	cooldown_time = 0.5 SECONDS
 	/// List of spans we add to the speaker.
 	var/list/voicespan = list(SPAN_COMMAND)
+	required_modpart_index = MOD_PART_HEAD
 
 /obj/item/mod/module/megaphone/on_activation()
 	. = ..()

--- a/code/modules/mod/modules/modules_visor.dm
+++ b/code/modules/mod/modules/modules_visor.dm
@@ -17,6 +17,7 @@
 	var/datum/component/neural_interface/interface
 	var/list/monitors = list()
 	var/interface_source
+	required_modpart_index = MOD_PART_HEAD
 
 /obj/item/mod/module/visor/on_activation()
 	. = ..()
@@ -36,7 +37,6 @@
 	for(var/trait in visor_traits)
 		ADD_TRAIT(mod.wearer, trait, MOD_TRAIT)
 	mod.wearer.update_sight()
-
 
 /obj/item/mod/module/visor/on_deactivation(display_message = TRUE, deleting = FALSE)
 	. = ..()


### PR DESCRIPTION
# Описание

Написал систему линковки модулей с конкретными частями МОДа, для того, чтобы соблюсти логику и некоторые модули не могли работать без активных надетых привязанных элементов костюма.

Починил работу черного списка для элементов МОДа, который запрещает разворачивать элементы МОД костюма поверх хардсьютов и их шлемов.

Починил MOD Paint Kit, он теперь корретно окрашивает элементы МОДа.

Починил Rad Protection Module.

## Причина изменений

надо


## Changelog

:cl:
add: Система линковки модулей с частями МОДа
fix: Исправлен черный список МОДа
fix: Исправлен MOD paint Kit
fix: Исправлен RAD Protection Module
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Модули MOD-костюмов теперь автоматически активируются и отключаются вместе с соответствующими частями костюма.
  * Для модулей введены требования к конкретным частям костюма: голове, перчаткам, обуви и другим элементам.
  * Недоступные или неготовые модули нельзя установить или активировать.
  * Улучшена перекраска частей костюма и выбор доступных модулей.
  * T-ray-модуль получил увеличенную дальность сканирования и сокращённое время перезарядки.

* **Исправления**
  * Предметы, являющиеся подтипами запрещённых для размещения, теперь также корректно отклоняются.
  * Исправлена обработка занятых слотов при взаимодействии с частями MOD-костюма.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->