### PR TITLE
ossmodula fix

### DIFF
--- a/modular_bluemoon/code/modules/surgery/organs/bioaegis_dangerous.dm
+++ b/modular_bluemoon/code/modules/surgery/organs/bioaegis_dangerous.dm
@@ -18,7 +18,7 @@
 	owner.adjustBruteLoss(-15, FALSE)
 	owner.adjustFireLoss(-15, FALSE)
 	owner.adjustStaminaLoss(1.5, FALSE) //It overloads body.
-	owner.adjustToxLoss(4, FALSE)
+	owner.adjustToxLoss(4, FALSE, TRUE)
 	owner.adjustOxyLoss(5, FALSE)
 
 /obj/item/organ/neuralderanger


### PR DESCRIPTION
# Описание
Про слаймов забыли

## Причина изменений
20+ пингов

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Optimia ossmodula дамажит слаймов, а не дает оверхил за бесплатно
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Устранена возможность сопротивления токсическому урону от перегрузки организма.
  * При срабатывании эффекта теперь гарантированно наносится 4 единицы токсического урона.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->