### PR TITLE
time_track evac fix

### DIFF
--- a/code/controllers/subsystem/memory_pressure_evac.dm
+++ b/code/controllers/subsystem/memory_pressure_evac.dm
@@ -136,6 +136,7 @@
 /// читалось без деталей работы с SSshuttle.
 /datum/controller/subsystem/time_track/proc/call_evac_on_memory(vsz, headroom_mb, minutes_left)
 	memory_evac_called = TRUE
+	GLOB.midround_recorded = TRUE
 
 	var/reason = "процесс занял [vsz] из [process_address_ceiling_mb] МБ адресного пространства \
 		([round(vsz / process_address_ceiling_mb * 100)]% потолка, до края [round(headroom_mb)] МБ), \

--- a/code/controllers/subsystem/memory_pressure_evac.dm
+++ b/code/controllers/subsystem/memory_pressure_evac.dm
@@ -136,7 +136,6 @@
 /// читалось без деталей работы с SSshuttle.
 /datum/controller/subsystem/time_track/proc/call_evac_on_memory(vsz, headroom_mb, minutes_left)
 	memory_evac_called = TRUE
-	GLOB.midround_recorded = TRUE
 
 	var/reason = "процесс занял [vsz] из [process_address_ceiling_mb] МБ адресного пространства \
 		([round(vsz / process_address_ceiling_mb * 100)]% потолка, до края [round(headroom_mb)] МБ), \
@@ -149,6 +148,7 @@
 
 	// Отзыв запрещается ДО вызова: между request() и следующей строкой мир успевает
 	// прокрутить тик, и экипаж, увидевший вызов, технически успевает нажать отзыв.
+	GLOB.midround_recorded = TRUE
 	SSshuttle.emergencyNoRecall = TRUE
 	SSshuttle.emergency.request(null, null, "Автоматическая эвакуация: критическое состояние систем станции.", FALSE, MEMORY_EVAC_CALL_COEFFICIENT)
 


### PR DESCRIPTION
# Описание
Чутка фиксим "Краш" сервера посредством эвака


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Исправлена фиксация состояния раунда при запуске эвакуации из-за высокого потребления памяти.
  * Состояние раунда теперь фиксируется только при наличии эвакуационного шаттла.
  * Улучшена последовательность действий при запуске эвакуации: фиксация выполняется непосредственно перед запретом отзыва шаттла.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->