### PR TITLE
Мехи-форсаж

### DIFF
--- a/code/__DEFINES/mecha.dm
+++ b/code/__DEFINES/mecha.dm
@@ -29,3 +29,8 @@
 #define MECHA_SECURE_BOLTS 1
 #define MECHA_LOOSE_BOLTS 2
 #define MECHA_OPEN_HATCH 3
+
+///Множитель задержки шага под форсажем ножных приводов
+#define MECHA_OVERLOAD_MOVEDELAY_MULT 0.5
+///Доля ёмкости ячейки, ниже которой форсаж ножных приводов не включается и сам отключается: мех обязан уйти своим ходом
+#define MECHA_OVERLOAD_POWER_RESERVE 0.1

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -304,6 +304,7 @@
 #include "jukebox_send_range.dm"
 #include "stationroom_landmark.dm"
 #include "latex_lockable.dm"
+#include "mecha_leg_overload.dm"
 #include "parallax_position.dm"
 #include "parallax_profiles.dm"
 #include "perf_cross_ports.dm"

--- a/code/modules/unit_tests/mecha_leg_overload.dm
+++ b/code/modules/unit_tests/mecha_leg_overload.dm
@@ -1,0 +1,104 @@
+///Форсаж ножных приводов (Gygax, Medical Gygax): включение ускоряет и дорожает шаг,
+///выключение возвращает штатные значения, кнопка отражает состояние шасси.
+///Ветки в Trigger были перепутаны с самого форка (tg починил в #53624): первое
+///нажатие только переворачивало флаг, второе - включало форсаж по 900 заряда за
+///шаг, и мех умирал через секунду. Репорт: "включил форсаж, выключил - мех встал
+///замертво, три Gygax бросили".
+/datum/unit_test/mecha_leg_overload
+	///Зона прогона: гравитацию возвращаем в Destroy(), потому что провал ассерта выходит из Run() сразу
+	var/area/test_area
+	var/saved_gravity
+
+/datum/unit_test/mecha_leg_overload/Destroy()
+	if(test_area)
+		test_area.has_gravity = saved_gravity
+		test_area = null
+	return ..()
+
+/datum/unit_test/mecha_leg_overload/Run()
+	var/turf/start_turf = run_loc_floor_bottom_left
+	//на резервационном z гравитации нет, а без неё шаг меха отказывает в Process_Spacemove
+	test_area = get_area(start_turf)
+	saved_gravity = test_area.has_gravity
+	test_area.has_gravity = STANDARD_GRAVITY
+
+	var/obj/vehicle/sealed/mecha/combat/gygax/mech = allocate(/obj/vehicle/sealed/mecha/combat/gygax, start_turf)
+	var/mob/living/carbon/human/pilot = allocate(/mob/living/carbon/human, start_turf)
+	//низкоуровневая посадка: moved_inside() требует клиента, которого у тестовых мобов нет
+	pilot.forceMove(mech)
+	mech.add_occupant(pilot)
+	var/datum/action/vehicle/sealed/mecha/mech_overload_mode/action = LAZYACCESSASSOC(mech.occupant_actions, pilot, /datum/action/vehicle/sealed/mecha/mech_overload_mode)
+	TEST_ASSERT_NOTNULL(action, "Санити: пилоту Gygax обязана выдаваться кнопка форсажа")
+	TEST_ASSERT_NOTNULL(mech.cell, "Санити: у меха с карты обязана быть ячейка")
+	var/base_delay = mech.movedelay
+	var/base_drain = mech.step_energy_drain
+	TEST_ASSERT_EQUAL(base_drain, mech.normal_step_energy_drain, "Санити: до форсажа цена шага штатная")
+	TEST_ASSERT(!mech.leg_overload_mode, "Санити: свежий мех без форсажа")
+
+	action.Trigger()
+	TEST_ASSERT(mech.leg_overload_mode, "Первое нажатие обязано ВКЛЮЧАТЬ форсаж")
+	TEST_ASSERT(mech.movedelay < base_delay, "Включённый форсаж обязан ускорять мех: задержка [mech.movedelay] против штатной [base_delay]")
+	TEST_ASSERT(mech.step_energy_drain > base_drain, "Включённый форсаж обязан дорожать: [mech.step_energy_drain] против штатной [base_drain]")
+	TEST_ASSERT_EQUAL(action.button_icon_state, "mech_overload_on", "Кнопка обязана показывать включённый форсаж")
+	var/overload_drain = mech.step_energy_drain
+
+	//шаг под форсажем берёт форсажную цену, а не штатную
+	mech.cell.charge = mech.cell.maxcharge
+	var/turf/east_turf = get_step(start_turf, EAST)
+	//vehicle_move() в чужую сторону только разворачивает мех, шаг - со второго вызова
+	mech.setDir(EAST)
+	TEST_ASSERT(mech.vehicle_move(EAST), "Санити: мех с полной ячейкой обязан шагать под форсажем")
+	TEST_ASSERT_EQUAL(get_turf(mech), east_turf, "Мех обязан сдвинуться на восток")
+	TEST_ASSERT_EQUAL(mech.cell.charge, mech.cell.maxcharge - overload_drain, "Шаг под форсажем обязан стоить форсажную цену")
+
+	action.Trigger()
+	TEST_ASSERT(!mech.leg_overload_mode, "Второе нажатие обязано ВЫКЛЮЧАТЬ форсаж")
+	TEST_ASSERT_EQUAL(mech.movedelay, base_delay, "После выключения форсажа задержка шага обязана вернуться к штатной")
+	TEST_ASSERT_EQUAL(mech.step_energy_drain, base_drain, "После выключения форсажа цена шага обязана вернуться к штатной")
+	TEST_ASSERT_EQUAL(mech.bumpsmash, initial(mech.bumpsmash), "После выключения форсажа таран обязан вернуться к типовому")
+	TEST_ASSERT_EQUAL(action.button_icon_state, "mech_overload_off", "Кнопка обязана показывать выключенный форсаж")
+
+	//резерв: форсаж не имеет права высушить ячейку досуха. На пороге он сам
+	//отключается, и тот же шаг проходит по штатной цене - мех уходит своим ходом
+	action.Trigger()
+	TEST_ASSERT(mech.leg_overload_mode, "Санити: третье нажатие снова включает форсаж")
+	var/reserve = mech.cell.maxcharge * MECHA_OVERLOAD_POWER_RESERVE
+	mech.cell.charge = reserve - 1
+	COOLDOWN_RESET(mech, cooldown_vehicle_move)
+	mech.setDir(WEST)
+	TEST_ASSERT(mech.vehicle_move(WEST), "Мех на резерве обязан шагать штатным ходом")
+	TEST_ASSERT_EQUAL(get_turf(mech), start_turf, "Мех обязан вернуться на запад")
+	TEST_ASSERT(!mech.leg_overload_mode, "На резерве заряда форсаж обязан отключиться сам")
+	TEST_ASSERT_EQUAL(action.button_icon_state, "mech_overload_off", "Кнопка обязана отразить самоотключение форсажа")
+	TEST_ASSERT_EQUAL(mech.cell.charge, reserve - 1 - base_drain, "Шаг после самоотключения обязан стоить штатную цену")
+	TEST_ASSERT_EQUAL(mech.movedelay, base_delay, "После самоотключения задержка шага штатная")
+
+	//на резерве форсаж не включается, вместо этого пилота предупреждают
+	action.Trigger()
+	TEST_ASSERT(!mech.leg_overload_mode, "На резерве заряда форсаж не обязан включаться")
+	TEST_ASSERT_EQUAL(mech.step_energy_drain, base_drain, "Отказ включения обязан оставить штатную цену шага")
+
+	//Medical Gygax таранит по умолчанию: выключение форсажа не должно это отнимать
+	var/obj/vehicle/sealed/mecha/medical/medigax/medigax = allocate(/obj/vehicle/sealed/mecha/medical/medigax, east_turf)
+	var/mob/living/carbon/human/medic = allocate(/mob/living/carbon/human, east_turf)
+	medic.forceMove(medigax)
+	medigax.add_occupant(medic)
+	var/datum/action/vehicle/sealed/mecha/mech_overload_mode/medigax_action = LAZYACCESSASSOC(medigax.occupant_actions, medic, /datum/action/vehicle/sealed/mecha/mech_overload_mode)
+	TEST_ASSERT_NOTNULL(medigax_action, "Санити: пилоту Medical Gygax обязана выдаваться кнопка форсажа")
+	TEST_ASSERT(medigax.bumpsmash, "Санити: Medical Gygax таранит по умолчанию")
+	medigax_action.Trigger()
+	TEST_ASSERT(medigax.leg_overload_mode, "Форсаж Medical Gygax обязан включаться с первого нажатия")
+	medigax_action.Trigger()
+	TEST_ASSERT(!medigax.leg_overload_mode, "Форсаж Medical Gygax обязан выключаться со второго нажатия")
+	TEST_ASSERT(medigax.bumpsmash, "Выключение форсажа не имеет права отнимать у Medical Gygax типовой таран")
+
+	//новый пилот получает кнопку в состоянии шасси, а не в дефолтном "выключено"
+	medigax_action.Trigger()
+	medigax.remove_occupant(medic)
+	medic.forceMove(east_turf)
+	var/mob/living/carbon/human/second_medic = allocate(/mob/living/carbon/human, east_turf)
+	second_medic.forceMove(medigax)
+	medigax.add_occupant(second_medic)
+	var/datum/action/vehicle/sealed/mecha/mech_overload_mode/second_action = LAZYACCESSASSOC(medigax.occupant_actions, second_medic, /datum/action/vehicle/sealed/mecha/mech_overload_mode)
+	TEST_ASSERT_NOTNULL(second_action, "Санити: второму пилоту обязана выдаваться кнопка форсажа")
+	TEST_ASSERT_EQUAL(second_action.button_icon_state, "mech_overload_on", "Кнопка нового пилота обязана показывать включённый форсаж шасси")

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -41,7 +41,7 @@
 	///How much energy we drain each time we mechpunch someone
 	var/melee_energy_drain = 15
 	///The minimum amount of energy charge consumed by leg overload
-	var/overload_step_energy_drain_min = 100
+	var/overload_step_energy_drain_min = 10
 	///chance to deflect the incoming projectiles, hits, or lesser the effect of ex_act.
 	var/deflect_chance = 10
 	///Modifiers for directional armor
@@ -140,8 +140,8 @@
 
 	///Bool for leg overload on/off
 	var/leg_overload_mode = FALSE
-	///Energy use modifier for leg overload
-	var/leg_overload_coeff = 100
+	///Во сколько раз шаг под форсажем ножных приводов дороже штатного
+	var/leg_overload_coeff = 10
 
 	//Bool for zoom on/off
 	var/zoom_mode = FALSE
@@ -194,6 +194,9 @@
 	add_cell()
 	add_scanmod()
 	add_capacitor()
+	//сборка с карты ставит детали мимо CheckParts(): без этого мех с карты
+	//платит за шаг типовые 10 вместо своей штатной цены
+	update_step_energy_drain()
 	START_PROCESSING(SSobj, src)
 	GLOB.poi_list |= src
 	AddComponent(/datum/component/hostile_machine_registry)
@@ -319,10 +322,9 @@
 /obj/vehicle/sealed/mecha/proc/update_part_values() ///Updates the values given by scanning module and capacitor tier, called when a part is removed or inserted.
 	if(scanmod)
 		normal_step_energy_drain = initial(normal_step_energy_drain) * (1.5 / (scanmod.rating - 0.5)) //movement power cost is 3x of default at T1, 1x at T2, 0.6x at T3 and 0.4x at T4
-		step_energy_drain = normal_step_energy_drain
 	else
 		normal_step_energy_drain = 500
-		step_energy_drain = normal_step_energy_drain
+	update_step_energy_drain()
 	if(capacitor)
 		armor = armor.modifyRating(energy = (capacitor.rating * 5)) //Each level of capacitor protects the mech against emp by 5%
 	else //because we can still be hit without a cap, even if we can't move
@@ -653,6 +655,45 @@
 		to_chat(occupants, "[icon2html(src, occupants)]<span class='warning'>Air port connection has been severed!</span>")
 		log_message("Lost connection to gas port.", LOG_MECHA)
 
+///Цена шага из штатной цены и состояния форсажа. Считается от штатной, а не от
+///текущей: повторное включение форсажа раньше умножало уже умноженное.
+/obj/vehicle/sealed/mecha/proc/update_step_energy_drain()
+	if(leg_overload_mode)
+		step_energy_drain = max(overload_step_energy_drain_min, normal_step_energy_drain * leg_overload_coeff)
+	else
+		step_energy_drain = normal_step_energy_drain
+
+///Неприкосновенный остаток ячейки под форсаж: ниже него форсаж не включается и сам гаснет,
+///чтобы мех всегда мог уйти к зарядке своим ходом. От реле Теслы резерва нет.
+/obj/vehicle/sealed/mecha/proc/leg_overload_reserve()
+	return cell ? cell.maxcharge * MECHA_OVERLOAD_POWER_RESERVE : 0
+
+///Включает или выключает форсаж ножных приводов: задержка шага, цена шага, таран,
+///кнопки всех пассажиров. Возвращает TRUE, если состояние сменилось; включение
+///на резерве заряда отклоняется. Сообщения пилоту пишет вызывающий.
+/obj/vehicle/sealed/mecha/proc/set_leg_overload(new_state)
+	new_state = !!new_state
+	if(leg_overload_mode == new_state)
+		return FALSE
+	if(new_state && get_charge() < leg_overload_reserve())
+		return FALSE
+	leg_overload_mode = new_state
+	log_message("Toggled leg actuators overload: [leg_overload_mode ? "on" : "off"].", LOG_MECHA)
+	if(leg_overload_mode)
+		bumpsmash = TRUE
+		movedelay = movement_quantize_delay(initial(movedelay) * MECHA_OVERLOAD_MOVEDELAY_MULT, world.tick_lag)
+	else
+		bumpsmash = initial(bumpsmash)
+		movedelay = initial(movedelay)
+	update_step_energy_drain()
+	for(var/mob/occupant as anything in occupants)
+		var/datum/action/action = LAZYACCESSASSOC(occupant_actions, occupant, /datum/action/vehicle/sealed/mecha/mech_overload_mode)
+		if(!action)
+			continue
+		action.button_icon_state = "mech_overload_[leg_overload_mode ? "on" : "off"]"
+		action.UpdateButtons()
+	return TRUE
+
 /obj/vehicle/sealed/mecha/proc/has_functional_thrusters()
 	return active_thrusters && !equipment_disabled && has_charge(step_energy_drain)
 
@@ -736,6 +777,9 @@
 
 	if(!COOLDOWN_FINISHED(src, cooldown_vehicle_move))
 		return FALSE
+	//форсаж гаснет на резерве ДО расчёта цены шага: этот же шаг идёт по штатной цене
+	if(leg_overload_mode && get_charge() < leg_overload_reserve() && set_leg_overload(FALSE))
+		to_chat(occupants, "[icon2html(src, occupants)]<span class='warning'>Leg actuators overload disabled: power reserve reached.</span>")
 	// Шаг меха живёт на собственном кулдауне, мимо /client/Move(), поэтому цену
 	// выравнивать по тику приходится здесь же. Дробный movedelay набегает от
 	// сканмодулей и капаситоров, а кулдаун всё равно проверяется только на тике.

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -9,8 +9,8 @@
 	deflect_chance = 5
 	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	max_temperature = 25000
-	leg_overload_coeff = 300
-	overload_step_energy_drain_min = 300
+	leg_overload_coeff = 30
+	overload_step_energy_drain_min = 30
 	force = 25
 	wreckage = /obj/structure/mecha_wreckage/gygax
 	internal_damage_threshold = 35
@@ -25,8 +25,8 @@
 	deflect_chance = 20
 	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 0, RAD =20, FIRE = 100, ACID = 100)
 	max_temperature = 35000
-	leg_overload_coeff = 100
-	overload_step_energy_drain_min = 100
+	leg_overload_coeff = 10
+	overload_step_energy_drain_min = 10
 	force = 30
 	operation_req_access = list(ACCESS_SYNDICATE)
 	internals_req_access = list(ACCESS_SYNDICATE)

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -179,27 +179,23 @@
 	name = "Toggle leg actuators overload"
 	button_icon_state = "mech_overload_off"
 
+///Кнопка нового пассажира обязана показывать состояние шасси, а не типовое "выключено"
+/datum/action/vehicle/sealed/mecha/mech_overload_mode/Grant(mob/grant_to)
+	button_icon_state = "mech_overload_[chassis?.leg_overload_mode ? "on" : "off"]"
+	return ..()
+
 /datum/action/vehicle/sealed/mecha/mech_overload_mode/Trigger(forced_state = null)
 	if(!owner || !chassis || !(owner in chassis.occupants))
 		return
-	if(!isnull(forced_state))
-		chassis.leg_overload_mode = forced_state
-	else
-		chassis.leg_overload_mode = !chassis.leg_overload_mode
-	chassis.log_message("Toggled leg actuators overload.", LOG_MECHA)
-	if(!chassis.leg_overload_mode)
-		button_icon_state = "mech_overload_on"
-		chassis.bumpsmash = TRUE
-		chassis.movedelay = min(1, round(chassis.movedelay * 0.5))
-		chassis.step_energy_drain = max(chassis.overload_step_energy_drain_min,chassis.step_energy_drain*chassis.leg_overload_coeff)
+	var/wanted_state = isnull(forced_state) ? !chassis.leg_overload_mode : forced_state
+	if(!chassis.set_leg_overload(wanted_state))
+		if(wanted_state && !chassis.leg_overload_mode)
+			to_chat(owner, "[icon2html(chassis, owner)]<span class='warning'>Insufficient power; cannot overload leg actuators.</span>")
+		return
+	if(chassis.leg_overload_mode)
 		to_chat(owner, "[icon2html(chassis, owner)]<span class='danger'>You enable leg actuators overload.</span>")
 	else
-		button_icon_state = "mech_overload_off"
-		chassis.bumpsmash = FALSE
-		chassis.movedelay = initial(chassis.movedelay)
-		chassis.step_energy_drain = chassis.normal_step_energy_drain
 		to_chat(owner, "[icon2html(chassis, owner)]<span class='notice'>You disable leg actuators overload.</span>")
-	UpdateButtons()
 
 /datum/action/vehicle/sealed/mecha/mech_smoke
 	name = "Smoke"


### PR DESCRIPTION
# Описание

Забыл докинуть к прошлой пачке фиксов.

Форсаж ножных приводов меха был перепутан с самого форка: первое нажатие ставило флаг, но применяло эффекты выключения, а второе — наоборот. Плюс цена шага умножалась от текущей, а не от штатной, так что каждое переключение копило коэффициент (300 → 90 000 → 27 000 000) и сажало ячейку за секунду.

Переключение вынесено в `set_leg_overload()`, цена шага всегда считается от штатной, коэффициенты приведены к правильной арифметике (Gygax 300 → 30, Dark Gygax 100 → 10), ниже 10% заряда форсаж не включается и гаснет сам

## Changelog

:cl:
fix: Форсаж ножных приводов меха включается с первого нажатия и больше не сажает ячейку за секунду
balance: Форсаж не включается и отключается сам ниже 10% заряда ячейки
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Улучшен форсаж ножных приводов мехов: изменяются скорость передвижения, расход энергии и сила тарана.
  * Состояние форсажа отображается на кнопке действия, включая состояние для нового пилота.
  * Форсаж автоматически отключается при снижении заряда до минимального резерва.

* **Исправления**
  * Невозможно включить форсаж при недостаточном заряде — отображается предупреждение.
  * Исправлена посадка пилота в мех и сохранение специальных свойств медицинской модели при отключении форсажа.
  * Скорректированы параметры форсажа для моделей Gygax и Dark Gygax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->