### PR TITLE
Ремаппинг Ксенобио - Бокс, Мета.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -26872,16 +26872,6 @@
 	dir = 1
 	},
 /area/maintenance/starboard/aft)
-"cgk" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen";
-	req_access_txt = "55"
-	},
-/turf/closed/wall,
-/area/medical/storage)
 "cgl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	external_pressure_bound = 120;
@@ -125143,7 +125133,7 @@ tBV
 oAo
 qbP
 oAo
-cgk
+tBV
 tBV
 joQ
 rik

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3,10 +3,10 @@
 /turf/open/space/basic,
 /area/space)
 "aad" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "aae" = (
 /obj/effect/landmark/carpspawn,
@@ -110,6 +110,11 @@
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "#d8b1b1"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 2";
+	dir = 8;
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -4247,6 +4252,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/science/xenobiology)
 "aBK" = (
@@ -4723,9 +4731,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/textured/large,
@@ -7530,10 +7543,18 @@
 /turf/open/floor/plating,
 /area/service/bar)
 "aQj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/science/xenobiology)
@@ -18254,9 +18275,6 @@
 /area/science)
 "bDm" = (
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19569,15 +19587,14 @@
 /area/hallway/primary/aft)
 "bIh" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white/textured/large,
+/turf/open/floor/plasteel/white/textured/half{
+	dir = 1
+	},
 /area/science/xenobiology)
 "bIl" = (
 /obj/structure/table/wood,
@@ -19931,9 +19948,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/science/xenobiology)
 "bJN" = (
@@ -20618,6 +20640,10 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology";
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/textured/large,
 /area/science/xenobiology)
@@ -21535,13 +21561,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "bPA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white/textured/large,
+/obj/machinery/camera{
+	c_tag = "Xenobiology South";
+	dir = 4;
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/plasteel/white/textured/half{
+	dir = 1
+	},
 /area/science/xenobiology)
 "bPF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -22320,17 +22350,15 @@
 /turf/open/floor/plasteel/textured/large,
 /area/science/xenobiology)
 "bRW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/biohazard,
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
+	id = "xenobio9";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bRY" = (
@@ -22347,6 +22375,9 @@
 	},
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel/textured/large,
 /area/science/xenobiology)
@@ -22844,34 +22875,28 @@
 	},
 /area/tcommsat/computer)
 "bUd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 4";
+	dir = 5;
+	network = list("ss13","xeno","rd")
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/yellow/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/textured/large,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bUe" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bUg" = (
@@ -23545,6 +23570,9 @@
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 10
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/textured/large,
 /area/science/xenobiology)
 "bWn" = (
@@ -24110,23 +24138,30 @@
 /turf/open/floor/wood/wood_diagonal,
 /area/security/prison/workout)
 "bYf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/yellow/line{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/textured/large,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bYg" = (
 /obj/structure/cable,
@@ -24462,22 +24497,31 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 4;
-	network = list("ss13","rd")
-	},
 /turf/open/floor/plasteel/white/textured/half{
 	dir = 1
 	},
 /area/science/xenobiology)
 "bZb" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
 	},
-/turf/open/floor/plasteel/white/textured/half{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 5
+	},
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel/textured/large,
 /area/science/xenobiology)
 "bZc" = (
 /obj/structure/frame/machine,
@@ -24800,6 +24844,9 @@
 	},
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel/textured/large,
 /area/science/xenobiology)
@@ -26527,17 +26574,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Kill Room";
-	dir = 4;
-	network = list("ss13","rd")
+	c_tag = "Xenobiology Cell 6";
+	dir = 5;
+	network = list("ss13","xeno","rd")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	external_pressure_bound = 140;
-	name = "killroom vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "cfs" = (
 /obj/effect/landmark/start/assistant,
@@ -26828,10 +26873,15 @@
 	},
 /area/maintenance/starboard/aft)
 "cgk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/biohazard,
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen";
+	req_access_txt = "55"
+	},
+/turf/closed/wall,
+/area/medical/storage)
 "cgl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	external_pressure_bound = 120;
@@ -27235,33 +27285,48 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cho" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
-"chq" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/light/small{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white/textured/half{
+	dir = 1
+	},
+/area/science/xenobiology)
+"chq" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "chr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Kill Chamber";
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/textured/large,
 /area/science/xenobiology)
 "chs" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/circuit/telecomms,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "chv" = (
 /obj/structure/cable{
@@ -33373,6 +33438,17 @@
 "cEQ" = (
 /turf/open/floor/plasteel/textured,
 /area/maintenance/starboard/aft)
+"cET" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 5";
+	dir = 5;
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "cFl" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown/half{
@@ -43920,9 +43996,9 @@
 	pixel_x = 11
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology West";
+	c_tag = "Xenobiology North";
 	dir = 8;
-	network = list("ss13","rd")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/white/textured/half{
 	dir = 1
@@ -51642,17 +51718,12 @@
 	},
 /area/medical/medbay/zone2)
 "jKu" = (
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South2";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/white/textured/half{
-	dir = 1
-	},
+/turf/open/floor/plasteel/white/textured/large,
 /area/science/xenobiology)
 "jKP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -58381,9 +58452,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/science/xenobiology)
 "mCh" = (
@@ -64335,6 +64408,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/textured/corner{
 	dir = 4
 	},
@@ -67226,6 +67302,19 @@
 	dir = 1
 	},
 /area/cargo/storage)
+"qkV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	external_pressure_bound = 140;
+	name = "killroom vent";
+	pressure_checks = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Kill Room";
+	dir = 4;
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "qlb" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -67895,7 +67984,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Test Chamber";
 	dir = 6;
-	network = list("ss13","rd","xeno")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72737,6 +72826,19 @@
 "sCm" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
+"sCM" = (
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "sCW" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/freezer,
@@ -76964,6 +77066,18 @@
 	dir = 8
 	},
 /area/security/prison/workout)
+"unC" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 3";
+	dir = 8;
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "unQ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -77221,30 +77335,25 @@
 /turf/open/floor/grass/grass0,
 /area/hallway/secondary/exit)
 "uuT" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen";
-	req_access_txt = "55"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
+	id = "xenobio9";
 	name = "containment blast door"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/research/glass{
+	name = "Kill Chamber";
+	req_one_access_txt = "55"
+	},
+/turf/open/floor/plasteel/textured/large,
 /area/science/xenobiology)
 "uve" = (
 /obj/structure/table,
@@ -77999,20 +78108,11 @@
 /turf/open/floor/plasteel/dark/textured/large,
 /area/service/bar)
 "uKf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology North";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/yellow/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/yellow/line,
-/turf/open/floor/plasteel/textured/large,
+/obj/machinery/light,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "uKt" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
@@ -78475,6 +78575,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/textured/half{
 	dir = 1
 	},
@@ -78864,12 +78970,16 @@
 /turf/open/floor/plasteel/textured/large,
 /area/hallway/primary/starboard)
 "vav" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/turf/open/floor/plasteel/white/textured/half{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 1";
+	dir = 8;
+	network = list("ss13","xeno","rd")
 	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "vaG" = (
 /obj/machinery/door/airlock/hop,
@@ -79540,6 +79650,13 @@
 	dir = 4
 	},
 /area/hallway/primary/starboard)
+"vqE" = (
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/turf/open/floor/plasteel/textured/large,
+/area/science/xenobiology)
 "vqP" = (
 /obj/structure/bed/dogbed{
 	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off.";
@@ -81171,7 +81288,12 @@
 /obj/effect/turf_decal/stripes/yellow/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/textured/half{
 	dir = 1
 	},
@@ -83378,19 +83500,16 @@
 	},
 /area/cargo/miningdock)
 "wOj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/button/door{
+	id = "xenobio9";
+	name = "Containment Blast Doors";
+	pixel_y = 23;
+	req_access_txt = "55";
+	pixel_x = -23
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/plasteel/white/textured/half{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white/textured/large,
 /area/science/xenobiology)
 "wOt" = (
 /obj/structure/chair/pew{
@@ -84305,8 +84424,8 @@
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/textured/half{
 	dir = 1
@@ -125024,7 +125143,7 @@ tBV
 oAo
 qbP
 oAo
-tBV
+cgk
 tBV
 joQ
 rik
@@ -128887,20 +129006,20 @@ cTX
 oXu
 vJd
 bDb
-bRT
+qkV
 aad
+bDb
+bRT
+bUd
 bEm
 bDb
 bRT
-aad
+cET
 bEm
 bDb
 bRT
-aad
-bEm
-bDb
 cfr
-cho
+bEm
 bDb
 bNA
 bMB
@@ -129144,9 +129263,8 @@ nnW
 bBx
 kVZ
 bDb
-bRU
-aml
-bEm
+cgi
+uKf
 bDb
 bRU
 aop
@@ -129156,8 +129274,9 @@ bRU
 aml
 eCH
 bDb
-cgi
-chq
+bRU
+aml
+eCH
 bDb
 cNW
 cNW
@@ -129401,9 +129520,8 @@ rxu
 cmh
 xWp
 bDb
-bRU
-amo
-bEm
+cgl
+chq
 bDb
 bRU
 amo
@@ -129413,8 +129531,9 @@ bRU
 amo
 cBz
 bDb
-cgi
-chq
+bRU
+amo
+cBz
 bDb
 cYo
 cNW
@@ -129660,7 +129779,6 @@ kVZ
 bDb
 bRW
 uuT
-bUe
 bDb
 bWl
 ycs
@@ -129670,7 +129788,8 @@ bZV
 jlW
 cbS
 bDb
-cgl
+bUe
+bYf
 chs
 bDb
 cmi
@@ -129914,20 +130033,20 @@ gmV
 gVs
 geH
 qpm
-czU
-bRV
-pql
-bUd
+bDb
+vqE
+sCM
 bIx
 bRV
 pql
-bYf
+bZb
 bIx
 bRV
 pql
 cbR
-bDb
-cgk
+bIx
+bRV
+pql
 chr
 bDb
 bDb
@@ -130172,18 +130291,18 @@ jYz
 hoE
 bMi
 bQM
-bMi
-weM
+wOj
 bRZ
-vav
+bMi
+bMi
 uSp
-weM
 bRZ
-bZa
 bMi
-weM
+bZa
+bIh
 bRZ
-jKu
+bPA
+bMi
 vSx
 xjO
 lQm
@@ -130431,18 +130550,18 @@ xXX
 hgf
 aqS
 mCg
-bIh
+xXX
 xXX
 aDt
-wOj
+mCg
 bDm
 xXX
 bJM
-wOj
-bPA
+mCg
+aBJ
 aBJ
 aQj
-bMk
+jKu
 bMk
 lyY
 sQK
@@ -130685,7 +130804,7 @@ bMm
 agH
 dFI
 bMi
-uKf
+bQM
 bRZ
 weM
 bMi
@@ -130693,14 +130812,14 @@ gEW
 bRZ
 weM
 gKf
-bZb
+bMi
 bRZ
 weM
 bMi
 bMi
 flc
-bZb
 bMi
+cho
 ceK
 bDb
 uLV
@@ -131972,7 +132091,7 @@ amS
 bPI
 bDb
 bEm
-abz
+vav
 bUi
 bDb
 bEm
@@ -131980,7 +132099,7 @@ abz
 bUi
 bDb
 bEm
-abz
+unC
 bUi
 bDb
 dul

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -60377,7 +60377,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/engineering/atmospherics_engine)
 "jsq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -21026,6 +21026,7 @@
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSh" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4262,6 +4262,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"aox" = (
+/obj/machinery/camera{
+	c_tag = "Xenobiology Maintenance";
+	dir = 1;
+	start_active = 1
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "aoz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20166,10 +20175,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bIv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bIx" = (
 /obj/structure/rack,
@@ -40485,12 +40494,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cLE" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 1;
-	name = "euthanization chamber freezer"
-	},
+/obj/structure/frame/machine,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/department/science/xenobiology)
 "cLF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -42225,21 +42231,27 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cRM" = (
-/obj/machinery/processor/slime,
 /obj/effect/turf_decal/stripes/yellow/corner,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8;
+	name = "Xenobiology air connection"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cRN" = (
-/obj/machinery/monkey_recycler,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/extinguisher{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/extinguisher,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cRR" = (
@@ -43020,7 +43032,7 @@
 "cTT" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
-/area/science/xenobiology)
+/area/maintenance/department/science/xenobiology)
 "cUm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -43724,8 +43736,8 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "daR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1;
@@ -43736,9 +43748,13 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "daS" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/item/stack/rods{
+	amount = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/science/xenobiology)
 "daX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -43813,9 +43829,10 @@
 /area/science/xenobiology)
 "dbv" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/small,
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel,
+/area/maintenance/department/science/xenobiology)
 "dbw" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Kill Chamber";
@@ -44007,15 +44024,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcf" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/processor/slime,
+/obj/effect/turf_decal/stripes/yellow/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44160,18 +44177,40 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcq" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcr" = (
-/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "xenobio9";
+	name = "Containment Blast Doors";
+	pixel_y = 55;
+	req_access_txt = "55";
+	pixel_x = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -44237,9 +44276,6 @@
 /area/science/xenobiology)
 "dcy" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcz" = (
@@ -44255,7 +44291,7 @@
 /area/science/xenobiology)
 "dcB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -44273,6 +44309,9 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/yellow/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -44306,33 +44345,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcJ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/extinguisher{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/extinguisher,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/yellow/corner{
 	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcK" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = -32
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dcL" = (
-/obj/machinery/light,
+"dcK" = (
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/purple,
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
@@ -44341,14 +44367,18 @@
 /obj/item/storage/box/syringes{
 	pixel_y = 5
 	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"dcL" = (
+/obj/machinery/light,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcM" = (
-/obj/machinery/chem_master,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
@@ -44357,10 +44387,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcN" = (
-/obj/machinery/chem_heater,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -44368,6 +44398,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcO" = (
@@ -44738,8 +44769,8 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "ddy" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -44749,26 +44780,21 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/department/science/xenobiology)
 "ddA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	glass = 1;
-	name = "Slime Euthanization Chamber";
-	opacity = 0;
-	req_access_txt = "55"
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "47"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "ddB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 1;
-	external_pressure_bound = 120;
-	name = "server vent"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/area/maintenance/department/science/xenobiology)
 "ddC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -44801,6 +44827,11 @@
 	req_access_txt = "55"
 	},
 /obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 2;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dfw" = (
@@ -45754,6 +45785,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dkH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio9";
+	name = "containment blast door"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "dkX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -45879,35 +45921,19 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "dmq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	glass = 1;
-	name = "Slime Euthanization Chamber";
-	opacity = 0;
-	req_access_txt = "55"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "dmr" = (
-/obj/machinery/door/airlock/research{
-	glass = 1;
-	name = "Slime Euthanization Chamber";
-	opacity = 0;
-	req_access_txt = "55"
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "dmL" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/freezer/coldroom,
@@ -47543,9 +47569,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dDI" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dDJ" = (
@@ -47619,6 +47642,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
+"dFH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio9";
+	name = "containment blast door"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "dFX" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -52874,12 +52906,11 @@
 /turf/open/floor/wood,
 /area/service/theater)
 "ggU" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to Distro"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/item/kirbyplants/random,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "ghb" = (
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -57212,11 +57243,9 @@
 	},
 /area/engineering/main)
 "idm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "idx" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -61322,6 +61351,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"kdE" = (
+/obj/item/chair,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/science/xenobiology)
 "kdR" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -61612,9 +61654,16 @@
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "kje" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8;
-	name = "Xenobiology air connection"
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 1;
+	name = "euthanization chamber freezer"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -63819,6 +63868,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"liw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/department/science/xenobiology)
 "lix" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -65610,7 +65669,7 @@
 /area/ai_monitored/security/armory)
 "lYC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -70256,6 +70315,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
+"odU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "oek" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -72545,6 +72611,21 @@
 /obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/command/bridge)
+"phu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "47"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "phP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -74519,6 +74600,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
+"qaE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_e";
+	name = "containment blast door"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "qaJ" = (
 /obj/structure/table,
 /obj/item/razor{
@@ -77009,6 +77098,15 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
 /area/service/sauna)
+"rcX" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "47"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "rcZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83262,12 +83360,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "tWd" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/storage/box/monkeycubes,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -83277,6 +83369,7 @@
 /obj/structure/sign/xenobio_guide{
 	pixel_y = 32
 	},
+/obj/machinery/monkey_recycler,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "tWo" = (
@@ -83458,6 +83551,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"uae" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 9
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "uam" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -87150,6 +87252,28 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"vOE" = (
+/obj/structure/fans/tiny,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/airlock/research/glass{
+	name = "Kill Chamber";
+	req_one_access_txt = "55"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio9";
+	name = "containment blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "vOQ" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/airless,
@@ -90523,6 +90647,10 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
 /area/service/library)
+"xnQ" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "xoe" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -126081,11 +126209,11 @@ cSn
 daF
 daJ
 cRi
-bvT
-cRi
-cRi
-cRi
-cRi
+phu
+dlV
+dlV
+dlV
+dlV
 aaa
 aai
 aaa
@@ -126338,11 +126466,11 @@ xIL
 lhY
 cSn
 cRi
+bvT
+dlV
+kdE
 dmq
-cRi
-cZv
-cZv
-cRi
+dlV
 aaf
 aag
 aaa
@@ -126597,9 +126725,9 @@ cSn
 cRi
 ddx
 ddz
-daR
-cZv
-qve
+liw
+dmr
+qaE
 aaa
 aaa
 aaa
@@ -126854,7 +126982,7 @@ daL
 cRi
 daQ
 ddA
-daS
+cTC
 dbv
 cTT
 ddC
@@ -127109,11 +127237,11 @@ daB
 jRB
 daK
 cRi
-bIv
-ddz
+cTA
+idm
 ddB
-cZv
-qve
+daS
+qaE
 aaa
 aaf
 aaa
@@ -127366,11 +127494,11 @@ tpE
 gTs
 daN
 cRi
-dmr
-cRi
-cZv
-dbw
-cRi
+cTA
+dlV
+ggU
+aox
+dlV
 aaa
 aag
 aaa
@@ -127598,7 +127726,7 @@ aaa
 cRi
 doj
 dcp
-idm
+cSt
 lYC
 dcK
 cSd
@@ -127623,11 +127751,11 @@ daE
 daI
 daM
 cRi
-cTA
-cRi
-cRi
-cRi
-cRi
+rcX
+dlV
+dlV
+dlV
+dlV
 aaf
 aag
 aaa
@@ -128111,8 +128239,8 @@ aaa
 aaa
 cRi
 tWd
+cZa
 cSt
-ggU
 dcC
 dcM
 cSd
@@ -128624,11 +128752,11 @@ aac
 aaa
 aaa
 cRi
-qve
-qve
-qve
+dkH
+vOE
+dFH
 cRi
-cRi
+qve
 cRi
 cRi
 cRi
@@ -128880,13 +129008,13 @@ aaf
 aaf
 aaf
 aaa
-aaa
-aaf
-aaf
-aaf
-aaf
-aaa
-aaa
+cRi
+cZv
+bIv
+daR
+xnQ
+sxe
+sxe
 aaf
 aaf
 aaf
@@ -129137,13 +129265,13 @@ aaa
 aaa
 aaf
 aaa
-aaa
+cRi
+odU
+uae
+dbw
+cRi
 lMJ
-aaa
-aaf
-aaa
-aaa
-aaa
+rpQ
 aaf
 aaa
 aaa
@@ -129394,13 +129522,13 @@ aaf
 aaf
 aaf
 aaa
+cRi
+cRi
+cRi
+cRi
+cRi
 aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 fqM
@@ -129652,15 +129780,15 @@ aaa
 aaf
 aaa
 aaa
-aqB
+lMJ
+aaa
+lMJ
 aaa
 aaa
-oRp
-oRp
-oRp
-oRp
-oRp
-oRp
+lMJ
+rpQ
+aaa
+aaa
 oRp
 oRp
 oRp
@@ -129909,15 +130037,15 @@ aaa
 aaf
 aaa
 aaf
-anT
+aaf
+aaa
+lMJ
+aaa
+lMJ
+lMJ
+rpQ
 aaa
 aaa
-oRp
-oRp
-oRp
-oRp
-oRp
-oRp
 oRp
 oRp
 oRp
@@ -130167,14 +130295,14 @@ anT
 anT
 aaf
 anT
+lMJ
+lMJ
+oDd
+lMJ
+lMJ
 aaa
 aaa
-oRp
-oRp
-oRp
-oRp
-oRp
-oRp
+aaa
 oRp
 oRp
 oRp
@@ -130425,13 +130553,13 @@ aaf
 aaa
 anT
 aaa
+oDd
+oDd
 aaa
-oRp
-oRp
-oRp
-oRp
-oRp
-oRp
+aaa
+aaa
+aaa
+aaa
 oRp
 oRp
 oRp
@@ -130683,12 +130811,12 @@ aaa
 aqB
 aaf
 aaa
-oRp
-oRp
-oRp
-oRp
-oRp
-oRp
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 oRp
 oRp
 oRp

--- a/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
+++ b/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
@@ -40608,7 +40608,6 @@
 	name = "test chamber blast door"
 	},
 /obj/effect/spawner/structure/window/plastitanium,
-/obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/engine,
 /area/maintenance/starboard/aft)
 "cAO" = (

--- a/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
+++ b/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
@@ -12,10 +12,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/service/bar)
 "aad" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "aae" = (
 /obj/effect/landmark/carpspawn,
@@ -340,6 +340,11 @@
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "#d8b1b1"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 1";
+	dir = 8;
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -3889,30 +3894,25 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "amG" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen";
-	req_access_txt = "55"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
+	id = "xenobio9";
 	name = "containment blast door"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/research/glass{
+	name = "Kill Chamber";
+	req_one_access_txt = "55"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "amH" = (
 /obj/machinery/door/window/northleft{
@@ -3999,7 +3999,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -4008,6 +4007,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "amQ" = (
@@ -4188,9 +4190,6 @@
 /area/science/xenobiology)
 "anp" = (
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -4351,9 +4350,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "anQ" = (
@@ -5494,13 +5498,17 @@
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/primary/fore)
 "aqG" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	external_pressure_bound = 140;
+	name = "killroom vent";
+	pressure_checks = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Kill Room";
+	dir = 4;
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "aqI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -5552,10 +5560,18 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aqS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
@@ -28369,6 +28385,10 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology";
+	network = list("ss13","xeno","rd")
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/science/xenobiology)
 "bMn" = (
@@ -29947,19 +29967,25 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/science/xenobiology)
 "bQN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology North";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/yellow/line{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/yellow/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 5
+	},
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/science/xenobiology)
 "bQO" = (
@@ -30420,7 +30446,7 @@
 /area/science/xenobiology)
 "bRY" = (
 /obj/structure/window/reinforced,
-/obj/structure/table/reinforced/plastitanium,
+/obj/structure/table/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -30432,6 +30458,9 @@
 	},
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/science/xenobiology)
@@ -31014,31 +31043,23 @@
 /turf/open/floor/mineral/plastitanium,
 /area/tcommsat/computer)
 "bUd" = (
-/obj/structure/table/reinforced/plastitanium,
-/obj/machinery/button/door{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_x = -32
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Xenobiology South";
+	dir = 4;
+	network = list("ss13","xeno","rd")
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/yellow/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "bUe" = (
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
-/obj/structure/cable,
+/obj/structure/sign/warning/biohazard,
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
+	id = "xenobio9";
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/plastitanium,
@@ -31449,10 +31470,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/primary/aft)
 "bVj" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bVk" = (
 /obj/structure/sink{
@@ -31460,9 +31479,9 @@
 	pixel_x = 11
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology West";
+	c_tag = "Xenobiology North";
 	dir = 8;
-	network = list("ss13","rd")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
@@ -31749,7 +31768,7 @@
 /area/science/xenobiology)
 "bWm" = (
 /obj/structure/window/reinforced,
-/obj/structure/table/reinforced/plastitanium,
+/obj/structure/table/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -31761,6 +31780,9 @@
 	},
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/science/xenobiology)
@@ -32468,23 +32490,16 @@
 /turf/open/floor/mineral/plastitanium,
 /area/medical/virology)
 "bYf" = (
-/obj/structure/table/reinforced/plastitanium,
-/obj/machinery/button/door{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 3";
+	dir = 8;
+	network = list("ss13","xeno","rd")
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/yellow/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bYg" = (
 /obj/structure/cable,
@@ -32809,16 +32824,18 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 4;
-	network = list("ss13","rd")
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "bZb" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes/yellow/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
@@ -33084,7 +33101,7 @@
 /area/science/xenobiology)
 "bZW" = (
 /obj/structure/window/reinforced,
-/obj/structure/table/reinforced/plastitanium,
+/obj/structure/table/reinforced,
 /obj/machinery/button/door{
 	id = "xenobio6";
 	name = "Containment Blast Doors";
@@ -33096,6 +33113,9 @@
 	},
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/science/xenobiology)
@@ -33665,24 +33685,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cbR" = (
-/obj/structure/table/reinforced/plastitanium,
-/obj/machinery/button/door{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/yellow/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "cbS" = (
 /obj/structure/cable,
@@ -34679,17 +34688,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Kill Room";
-	dir = 4;
-	network = list("ss13","rd")
+	c_tag = "Xenobiology Cell 6";
+	dir = 5;
+	network = list("ss13","xeno","rd")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	external_pressure_bound = 140;
-	name = "killroom vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "cft" = (
 /obj/machinery/door/airlock/maintenance{
@@ -34938,9 +34945,16 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "cgk" = (
-/obj/effect/spawner/structure/window/plastitanium,
-/obj/structure/sign/warning/biohazard,
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 2";
+	dir = 8;
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "cgl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -35347,40 +35361,58 @@
 /turf/open/floor/mineral/plastitanium,
 /area/maintenance/disposal/incinerator)
 "cho" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "chq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "chr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Kill Chamber";
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 5
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/science/xenobiology)
 "chs" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/circuit/telecomms,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/effect/spawner/structure/window/plastitanium,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "chu" = (
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
@@ -40576,6 +40608,7 @@
 	name = "test chamber blast door"
 	},
 /obj/effect/spawner/structure/window/plastitanium,
+/obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/engine,
 /area/maintenance/starboard/aft)
 "cAO" = (
@@ -42569,13 +42602,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "cTY" = (
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South2";
-	dir = 4;
-	network = list("ss13","rd")
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
@@ -42583,7 +42611,12 @@
 /obj/effect/turf_decal/stripes/yellow/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "cUb" = (
@@ -43228,6 +43261,17 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/engineering/atmos)
+"diV" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 5";
+	dir = 5;
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "djr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45936,10 +45980,10 @@
 	id = "misclab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/plastitanium,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/engine,
 /area/maintenance/starboard/aft)
 "eOP" = (
@@ -48899,9 +48943,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -53045,6 +53094,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "ixo" = (
@@ -54867,6 +54919,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "jwb" = (
@@ -55015,6 +55073,9 @@
 "jBk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
@@ -56620,18 +56681,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ktT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/button/door{
+	id = "xenobio9";
+	name = "Containment Blast Doors";
+	pixel_y = 23;
+	req_access_txt = "55";
+	pixel_x = -23
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/science/xenobiology)
 "ktW" = (
@@ -58329,16 +58385,11 @@
 /turf/open/floor/grass,
 /area/service/park)
 "loV" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/turf/open/floor/mineral/plastitanium/red,
 /area/science/xenobiology)
 "lpj" = (
 /obj/structure/chair/stool{
@@ -59379,7 +59430,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lOy" = (
-/obj/structure/table/reinforced/plastitanium,
+/obj/structure/table,
 /obj/item/folder/white,
 /obj/item/wrench,
 /obj/item/pen,
@@ -67811,6 +67862,32 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solars/port/fore)
+"qhN" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen";
+	req_access_txt = "55"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "qhW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -71649,6 +71726,26 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/primary/central)
+"siX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/science/xenobiology)
 "skE" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -76630,6 +76727,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/red,
 /area/service/janitor)
+"uRl" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 4";
+	dir = 5;
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "uRP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -125294,20 +125402,20 @@ bIh
 jBk
 bPx
 ocR
-bRT
+aqG
 aad
+ocR
+bRT
+uRl
 bEm
 ocR
 bRT
-aad
+diV
 bEm
 ocR
 bRT
-aad
-bEm
-ocR
 cfr
-cho
+bEm
 ocR
 bNA
 bMB
@@ -125551,9 +125659,8 @@ bNo
 bIP
 bPA
 ocR
-bRU
-aml
-bEm
+cgi
+chq
 ocR
 bRU
 aop
@@ -125563,8 +125670,9 @@ bRU
 aml
 dQl
 ocR
-cgi
-chq
+bRU
+aml
+dQl
 ocR
 kfS
 kfS
@@ -125808,9 +125916,8 @@ bIt
 ech
 bPz
 ocR
-bRU
-amo
-bEm
+cgl
+bVj
 ocR
 bRU
 amo
@@ -125820,8 +125927,9 @@ bRU
 amo
 cBz
 ocR
-cgi
-chq
+bRU
+amo
+cBz
 ocR
 eFB
 kfS
@@ -126065,9 +126173,8 @@ alm
 aln
 bPA
 ocR
-bRW
-amG
 bUe
+amG
 ocR
 bWl
 aoq
@@ -126077,7 +126184,8 @@ bZV
 apw
 cbS
 ocR
-cgl
+bRW
+qhN
 chs
 ocR
 idA
@@ -126321,20 +126429,20 @@ ltN
 bIu
 bIO
 alx
-bLe
-bRV
-amH
-bUd
-bIx
-bRV
-amH
-bYf
-bIx
-bRV
-amH
-cbR
 ocR
-cgk
+loV
+bZb
+bIx
+bRV
+amH
+bQN
+bIx
+bRV
+amH
+siX
+bIx
+bRV
+amH
 chr
 ocR
 ocR
@@ -126579,18 +126687,18 @@ bNp
 ech
 bMi
 bQM
-bMi
-bOx
+ktT
 bRZ
-bVj
+bMi
+bMi
 jvX
-bOx
 bRZ
-bZa
 bMi
-bOx
+bZa
+cbR
 bRZ
-cTY
+bUd
+bMi
 cTZ
 chu
 ccQ
@@ -126837,8 +126945,8 @@ bIQ
 anx
 amh
 ami
-ktT
-loV
+amP
+anx
 anx
 glt
 amP
@@ -126846,10 +126954,10 @@ anp
 anx
 anN
 amP
-aqG
+ixg
 ixg
 aqS
-asr
+cho
 asr
 asC
 fjI
@@ -127092,7 +127200,7 @@ bMm
 bNp
 bMi
 bMi
-bQN
+bQM
 bRZ
 bOx
 bMi
@@ -127100,14 +127208,14 @@ bVk
 bRZ
 bOx
 xLl
-bZb
+bMi
 bRZ
 bOx
 bMi
 bMi
 cgn
-bZb
 bMi
+cTY
 uPB
 ocR
 cgm
@@ -128383,11 +128491,11 @@ abz
 bUi
 ocR
 bEm
-abz
+cgk
 bUi
 ocR
 bEm
-abz
+bYf
 bUi
 ocR
 qKm


### PR DESCRIPTION
# Описание

Комнаты заморозки слаймов были перенесены ближе к консолям и основному рабочему места для удобства в эксплуатации.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Эти комнаты находились слишком далеко, поэтому ими никто не пользовался.

## Демонстрация изменений

Мета:
<img width="802" height="622" alt="image" src="https://github.com/user-attachments/assets/a211a57d-2a20-4437-a873-94d7ea05356a" />
<img width="639" height="513" alt="image" src="https://github.com/user-attachments/assets/6f638fd6-6021-415d-81f0-80d312cd8955" />

Бокс:
<img width="678" height="857" alt="image" src="https://github.com/user-attachments/assets/9ba0e90b-a89c-4880-95be-e22c5509e97b" />

## Changelog

:cl:
map: Бокс, Мета: Изменение Ксенобио. Комнаты заморозки слаймов перенесены ближе к рабочему месту.
map: Дельта: Инжекторы газа в контуре фильтрации СМа теперь работают.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Изменения карт**
  * Обновлены зоны ксенобиологии на BoxStation, MetaStation и Syndicate Box Station.
  * Переработаны Kill Room, Containment Pen и исследовательские помещения: изменены шлюзы, камеры, вентиляция, освещение и кабельные сети.
  * Добавлены новые технические элементы, декоративные объекты и обновлённые точки доступа.
  * Удалены устаревшие помещения и оборудование, включая старую камеру эвтаназии слизней на MetaStation.
  * Исправлена принадлежность участка космоса к инженерной зоне атмосферики на DeltaStation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->