### PR TITLE
Добавлено бронепальто синдиката в кэп венд.

### DIFF
--- a/modular_bluemoon/code/modules/vending/wardrobes.dm
+++ b/modular_bluemoon/code/modules/vending/wardrobes.dm
@@ -775,6 +775,8 @@
 					/obj/item/clothing/under/bm/caprevskirt = 2, // BlueMoon Add
 					/obj/item/clothing/under/bm/regaloutfit = 2, // BlueMoon Add
 					/obj/item/clothing/suit/captunic = 1,
+					/obj/item/clothing/suit/toggle/captains_parade/syndicate/winter = 1, // BlueMoon Add
+					/obj/item/clothing/suit/toggle/captains_parade/syndicate = 1, // BlueMoon Add
 					/obj/item/clothing/under/rank/captain/femformal = 2,
 					/obj/item/clothing/glasses/sunglasses/gar/supergar = 1,
 					/obj/item/clothing/gloves/color/captain = 1,


### PR DESCRIPTION
# Описание

ЧЧувак попросил добавить Синди шмотку в вендомат. Поскольку у нас пакт я и добавил. Две вариации обычная и зимня. По сути рескин панциря капитана.
- [ x] Изменения были проверены на локальном сервере
- [x ] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

Запрос игрока который вот вообще никак не повлияет на игру негативно. Кроме как косметически

## Демонстрация изменений
![Uploading изображение.png…]()


<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

:cl:
add: Added Syndicate Captain vest (normal and winter variant) in the Cap Drobe.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * В гардеробе капитана появились два новых предмета одежды: обычный и зимний парадные кители синдиката.
  * Каждый предмет доступен в количестве одной единицы.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->