### PR TITLE
Tiny fan разбирается при разборке пола под ним

### DIFF
--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -220,19 +220,19 @@
 	var/turf/fan_turf = get_turf(remote_eye)
 
 	if(!B.fans_remaining)
-		to_chat(owner, "<span class='warning'>[B] is out of fans!</span>")
+		to_chat(owner, span_warning("У [B] закончились вентиляторы!"))
 		return
 
 	if(!check_spot())
 		return
 
 	if(!isfloorturf(fan_turf))
-		to_chat(owner, "<span class='warning'>Fans may only be placed on a floor.</span>")
+		to_chat(owner, span_warning("Вентилятор можно установить только на твёрдой поверхности."))
 		return
 
 	new /obj/structure/fans/tiny(fan_turf)
 	B.fans_remaining--
-	to_chat(owner, "<span class='notice'>Tiny fan placed. [B.fans_remaining] remaining.</span>")
+	to_chat(owner, span_notice("Вентилятор размещён. Ещё [B.fans_remaining] осталось в запасе."))
 	playsound(fan_turf, 'sound/machines/click.ogg', 50, 1)
 
 /datum/action/innate/aux_base/install_turret

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -226,7 +226,7 @@
 	if(!check_spot())
 		return
 
-	if(fan_turf.density)
+	if(!isfloorturf(fan_turf))
 		to_chat(owner, "<span class='warning'>Fans may only be placed on a floor.</span>")
 		return
 

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -322,6 +322,24 @@
 	icon_state = "fan_tiny"
 	buildstackamount = 10
 
+/obj/structure/fans/tiny/Initialize(mapload)
+	. = ..()
+	if(!mapload && !isfloorturf(loc))
+		return INITIALIZE_HINT_QDEL
+	if(isfloorturf(loc))
+		RegisterSignal(loc, COMSIG_PARENT_QDELETING, PROC_REF(on_parent_turf_qdeleting))
+
+/obj/structure/fans/tiny/Destroy()
+	if(isfloorturf(loc))
+		UnregisterSignal(loc, COMSIG_PARENT_QDELETING)
+	return ..()
+
+// source передаётся через SEND_SIGNAL сигнала COMSIG_PARENT_QDELETING, как D, заявленный как loc в RegisterSignal() внутри Initialize()
+/obj/structure/fans/tiny/proc/on_parent_turf_qdeleting(datum/source)
+	SIGNAL_HANDLER
+	if(source == loc && !QDELETED(src))
+		deconstruct()
+
 /obj/structure/fans/Initialize(mapload)
 	. = ..()
 	air_update_turf(TRUE)
@@ -329,6 +347,7 @@
 //Inivisible, indestructible fans
 /obj/structure/fans/tiny/invisible
 	name = "air flow blocker"
+	flags_1 = NODECONSTRUCT_1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	invisibility = INVISIBILITY_ABSTRACT
 


### PR DESCRIPTION
# Описание
- `tiny fan` при инициализации регистрируется сигналом к loc-турфу пола и разбирается, если удалился родитель-турф.
- Голодрон в конструкционной комнате (Где отправляется под, это который обычно над прибытием) проверяет не плотность турфа, а его статус пола.
- Невидимые мапперские `tiny fan` не будут дропать железо при деконстракте.

## Причина изменений
Запрос хоста. Моя солидарность с ним в вопросе, что это недоработка кода, ломающая погружение и иммерсивность выживания в рамках космической станции, т.к. висящий в вакууме вентилятор блокировал вакуум, в котором находится.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Тинифан теперь разбирается на металл при разборе/уничтожении/удалении пола, на котором он находится.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Размещение маленького вентилятора в консоли строительства базы теперь разрешено только на напольных тайлах.
  * Добавлена корректная обработка вентиляторов при удалении или разрушении пола: устройство автоматически разбирается, предотвращая появление зависших объектов.
  * Вентиляторы, созданные вне карты на неподходящей поверхности, автоматически удаляются.
  * Невидимые варианты вентиляторов нельзя разобрать вручную.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->