### PR TITLE
Починил бимбопены

### DIFF
--- a/modular_splurt/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -20,12 +20,12 @@
 
 /datum/chemical_reaction/anal_allure
 	results = list(/datum/reagent/drug/genital_stimulator/anal_allure = 2)
-	required_container = /obj/item/reagent_containers/beaker
+	required_container = /obj/item/reagent_containers/glass
 	required_reagents = list(/datum/reagent/drug/aphrodisiacplus = 1, /datum/reagent/fermi/butt_enlarger = 1)
 
 /datum/chemical_reaction/breast_buzzer
 	results = list(/datum/reagent/drug/genital_stimulator/breast_buzzer = 2)
-	required_container = /obj/item/reagent_containers/beaker
+	required_container = /obj/item/reagent_containers/glass
 	required_reagents = list(/datum/reagent/drug/aphrodisiacplus = 1, /datum/reagent/fermi/breast_enlarger = 1)
 
 /datum/chemical_reaction/peen_pop

--- a/modular_splurt/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -20,10 +20,12 @@
 
 /datum/chemical_reaction/anal_allure
 	results = list(/datum/reagent/drug/genital_stimulator/anal_allure = 2)
+	required_container = TRUE
 	required_reagents = list(/datum/reagent/drug/aphrodisiacplus = 1, /datum/reagent/fermi/butt_enlarger = 1)
 
 /datum/chemical_reaction/breast_buzzer
 	results = list(/datum/reagent/drug/genital_stimulator/breast_buzzer = 2)
+	required_container = TRUE
 	required_reagents = list(/datum/reagent/drug/aphrodisiacplus = 1, /datum/reagent/fermi/breast_enlarger = 1)
 
 /datum/chemical_reaction/peen_pop

--- a/modular_splurt/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -20,12 +20,12 @@
 
 /datum/chemical_reaction/anal_allure
 	results = list(/datum/reagent/drug/genital_stimulator/anal_allure = 2)
-	required_container = TRUE
+	required_container = /obj/item/reagent_containers
 	required_reagents = list(/datum/reagent/drug/aphrodisiacplus = 1, /datum/reagent/fermi/butt_enlarger = 1)
 
 /datum/chemical_reaction/breast_buzzer
 	results = list(/datum/reagent/drug/genital_stimulator/breast_buzzer = 2)
-	required_container = TRUE
+	required_container = /obj/item/reagent_containers
 	required_reagents = list(/datum/reagent/drug/aphrodisiacplus = 1, /datum/reagent/fermi/breast_enlarger = 1)
 
 /datum/chemical_reaction/peen_pop

--- a/modular_splurt/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/modular_splurt/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -20,12 +20,12 @@
 
 /datum/chemical_reaction/anal_allure
 	results = list(/datum/reagent/drug/genital_stimulator/anal_allure = 2)
-	required_container = /obj/item/reagent_containers
+	required_container = /obj/item/reagent_containers/beaker
 	required_reagents = list(/datum/reagent/drug/aphrodisiacplus = 1, /datum/reagent/fermi/butt_enlarger = 1)
 
 /datum/chemical_reaction/breast_buzzer
 	results = list(/datum/reagent/drug/genital_stimulator/breast_buzzer = 2)
-	required_container = /obj/item/reagent_containers
+	required_container = /obj/item/reagent_containers/beaker
 	required_reagents = list(/datum/reagent/drug/aphrodisiacplus = 1, /datum/reagent/fermi/breast_enlarger = 1)
 
 /datum/chemical_reaction/peen_pop


### PR DESCRIPTION
# Описание

Бимбопены изначально НЕ должны были работать, потому что содержали реагенты, которые по определению смешиваются между собой. Но химия внутри моба не мешалась из-за бага. Баг исправили - бимбопены сломались. Починил. Запретил этим реакциям вариться без колбы. 

выполнено по багрепорту:
https://discord.com/channels/875735187449847830/1540485922188034149

## Причина изменений
Бимбопены не работали как должны

:cl:
fix: починил бимбопены
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Для реакций `anal_allure` и `breast_buzzer` теперь требуется подходящий контейнер.
  * Состав реагентов и результаты реакций не изменились.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->