### PR TITLE
Небольшая обнова ДС-2.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -5641,7 +5641,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit,
+/obj/machinery/suit_storage_unit/syndicate/command,
 /turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "vB" = (
@@ -8418,9 +8418,11 @@
 /obj/item/gun/energy/lasercannon{
 	pixel_y = 8
 	},
-/obj/item/gun/ballistic/shotgun/automatic/combat,
-/obj/item/gun/energy/e_gun/stun{
-	pixel_y = -9
+/obj/item/gun/energy/modular_laser_rifle/carbine{
+	pixel_y = 1
+	},
+/obj/item/gun/energy/modular_laser_rifle/carbine{
+	pixel_y = -5
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)


### PR DESCRIPTION
# Описание

Нет не добавление ТЭГа. Ласка попросил добавить Хоши подкипив это скрином где смайли согласен. Готово тактичка и никому ненужный дробовик заменены.
Далее пофиксил хранилище костюма Адмирала которое потеряло всякий смысл с введением последнего апдате.
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
## Причина изменений
Фикс небольшой ошибки маппинга ранее. И запрос на восстановление "исторической справедливости" с оружием Киберсан.
## Changelog

Заменил храналище скафандра для Адмирала на походящий. 
Заменил дробовик и тактическую лазерку на Хоши. (Да простят меня игроки кто будет брать соулкатчер Ласки).
:cl:
add: Added Hoshi car. in the DS-2 armory
del: Tactical E-Gun and C-shotgun from DS-2 armory
fix: Placed fitting SSU inside DS-2 Admiral quarters