### PR TITLE
Правки Патронов

### DIFF
--- a/code/modules/projectiles/projectile/bullets/ferromagnetic.dm
+++ b/code/modules/projectiles/projectile/bullets/ferromagnetic.dm
@@ -2,7 +2,7 @@
 /obj/item/projectile/bullet/magnetic
 	icon_state = "magjectile"
 	damage = 25
-	armour_penetration = BULLET_BR3   // BLUEMOON EDIT: поднимаем значимость
+	armour_penetration = BULLET_BR4   // BLUEMOON EDIT: поднимаем значимость
 	fired_light_range = 3
 	pixels_per_second = TILES_TO_PIXELS(16.667)
 	range = 35

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -1,17 +1,17 @@
 // C3D (Борги) — BR2 (технический)
 /obj/item/projectile/bullet/c3d
 	damage = 30
-	armour_penetration = BULLET_BR2   // BLUEMOON ADD
+	armour_penetration = BULLET_BR4   // BLUEMOON ADD
 
 // Mech LMG — BR2
 /obj/item/projectile/bullet/lmg
 	damage = 30
-	armour_penetration = BULLET_BR2   // BLUEMOON ADD
+	armour_penetration = BULLET_BR4   // BLUEMOON ADD
 
 // Mech FNX-99 — BR2
 /obj/item/projectile/bullet/incendiary/fnx99
 	damage = 30
-	armour_penetration = BULLET_BR2   // BLUEMOON ADD
+	armour_penetration = BULLET_BR5   // BLUEMOON ADD
 
 // Турели
 /obj/item/projectile/bullet/manned_turret

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -136,7 +136,7 @@
 /obj/item/projectile/bullet/a357
 	name = ".357 bullet"
 	damage = 65
-	armour_penetration = BULLET_BR2   // BLUEMOON ADD: явно BR2(20), было 0
+	armour_penetration = BULLET_BR3
 	wound_bonus = 25
 	ricochets_max = 2
 	ricochet_chance = 100
@@ -144,7 +144,7 @@
 /obj/item/projectile/bullet/a357/ap
 	name = ".357 armor-piercing bullet"
 	damage = 50
-	armour_penetration = BULLET_BR4   // BLUEMOON EDIT: было 45 → BR4(50)
+	armour_penetration = BULLET_BR5   // BLUEMOON EDIT
 
 // admin only really, for ocelot memes
 /obj/item/projectile/bullet/a357/match

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -2,8 +2,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 45
-	armour_penetration = BULLET_BR2   // BLUEMOON EDIT: было 30 → BR2(20)... нет, было 30
-// оставляем 30 как есть (между BR2 и BR3, допустимо)
+	armour_penetration = BULLET_BR3
 	sharpness = SHARP_POINTY
 	wound_bonus = 6
 
@@ -111,7 +110,7 @@
 	name = "buckshot pellet"
 	icon_state = "pellet"
 	damage = 12.5                     // BLUEMOON EDIT: было 7.5 → 12.5 (конкретно Bluemoon переопределение)
-	armour_penetration = BULLET_BR1   // BLUEMOON ADD
+	armour_penetration = BULLET_BR4   // BLUEMOON ADD
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5  // low damage + additional dropoff will already curb wounding potential anything past point blank
@@ -142,7 +141,7 @@
 // Самодельная дробь — BR0 (ненадёжная, слабая)
 /obj/item/projectile/bullet/pellet/shotgun_improvised
 	icon_state = "pellet"
-	armour_penetration = BULLET_BR0
+	armour_penetration = BULLET_BR3
 	tile_dropoff = 0.35
 	damage = 6
 	wound_bonus = 0
@@ -160,7 +159,7 @@
 
 /obj/item/projectile/bullet/scattershot
 	damage = 20
-	armour_penetration = BULLET_BR1
+	armour_penetration = BULLET_BR6
 
 /obj/item/projectile/bullet/seed
 	armour_penetration = BULLET_BR0

--- a/modular_splurt/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/modular_splurt/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -115,7 +115,7 @@
 /obj/item/projectile/bullet/g45l/lethal
 	name = ".45 Long Lethal bullet"
 	damage = 35
-	armour_penetration = BULLET_BR1   // BLUEMOON ADD
+	armour_penetration = BULLET_BR4   // BLUEMOON ADD
 	wound_bonus = 15
 	stamina = 0
 	sharpness = SHARP_EDGED


### PR DESCRIPTION
Ребаланс лёгкий пробития патрнов на которые жаловались.
Бакшоты теперь пробивают больше.
Оружие мехов повысил бронепробитие.
Магнитка. прбитие повышено. 
Револьвер 357 и патрон 45 лон повышен.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения игрового баланса**
  * Повышена бронепробиваемость стандартных магнитных, пулемётных и револьверных боеприпасов.
  * Улучшена эффективность против брони для ряда патронов .357, включая бронебойный вариант.
  * Повышена бронепробиваемость дробовых боеприпасов: slug, buckshot, самодельной дроби и scattershot.
  * Усилен показатель бронепробиваемости винтовочного боеприпаса .45 Long Lethal.
  * Урон, бонусы к ранениям и вероятность рикошета затронутых боеприпасов не изменялись.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->