### PR TITLE
Добавил речарджеры для модов

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36955,6 +36955,12 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/dark/textured/large,
 /area/command/heads_quarters/hos/private)
+"dMU" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/textured/half{
+	dir = 8
+	},
+/area/engineering/break_room)
 "dNd" = (
 /obj/structure/filingcabinet{
 	pixel_x = 5
@@ -51046,9 +51052,13 @@
 /area/security/prison/workout)
 "jue" = (
 /obj/structure/table/reinforced,
-/obj/item/assembly/flash/handheld,
+/obj/item/storage/fancy/donut_box{
+	pixel_x = -4;
+	pixel_y = -2
+	},
 /obj/item/assembly/flash/handheld{
-	pixel_x = 8
+	pixel_x = 10;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark/textured/large,
 /area/command/bridge)
@@ -67211,10 +67221,10 @@
 /turf/open/floor/plasteel/white,
 /area/command/blueshieldoffice)
 "qex" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 10
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/textured/large,
 /area/security/brig)
 "qeH" = (
@@ -71982,12 +71992,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "sfq" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/donut_box,
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark/textured/large,
 /area/command/bridge)
 "sfr" = (
@@ -118026,7 +118031,7 @@ caA
 bVr
 bXN
 lPx
-bZE
+dMU
 jiK
 vVr
 mkQ

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -11112,6 +11112,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "bGn" = (
@@ -39334,6 +39335,7 @@
 /obj/effect/turf_decal/tile/dark{
 	dir = 8
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "eQZ" = (
@@ -122915,6 +122917,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "wwX" = (
@@ -129921,6 +129924,7 @@
 	c_tag = "Security - Office Fore";
 	dir = 4
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
 /area/security/brig_briefing)
 "xYZ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32932,6 +32932,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
 /area/medical/paramedic)
 "cwE" = (
@@ -65901,6 +65902,7 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "mah" = (
@@ -78202,6 +78204,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "ryN" = (
@@ -92556,6 +92559,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
 /area/security/office)
 "xXd" = (

--- a/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
+++ b/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
@@ -2433,10 +2433,10 @@
 /turf/open/floor/wood,
 /area/hallway/primary/fore)
 "aiG" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 10
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/mineral/plastitanium/red,
 /area/security/brig)
 "aiL" = (
@@ -12684,9 +12684,12 @@
 /area/command/bridge)
 "aSv" = (
 /obj/structure/table/reinforced/plastitanium,
-/obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld{
 	pixel_x = 8
+	},
+/obj/item/storage/fancy/donut_box{
+	pixel_x = 3;
+	pixel_y = 6
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/command/bridge)
@@ -13282,12 +13285,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/command/bridge)
 "aUc" = (
-/obj/structure/table/reinforced/plastitanium,
-/obj/item/storage/fancy/donut_box{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/donut_box,
+/obj/machinery/recharge_station,
 /turf/open/floor/mineral/plastitanium,
 /area/command/bridge)
 "aUe" = (
@@ -45913,6 +45911,10 @@
 	},
 /turf/open/floor/wood/wood_diagonal,
 /area/service/hydroponics/garden)
+"eMz" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/mineral/plastitanium,
+/area/engineering/break_room)
 "eNr" = (
 /obj/effect/turf_decal/loading_area{
 	icon_state = "half_stairs_wood";
@@ -71976,16 +71978,16 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/obj/item/flashlight/lamp{
-	pixel_x = -6;
-	pixel_y = 10
-	},
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/obj/item/flashlight/lamp{
+	pixel_x = -6;
+	pixel_y = 10
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/medical/paramedic)
 "skN" = (
@@ -114385,7 +114387,7 @@ caA
 bVr
 bXN
 bZy
-bZy
+eMz
 cig
 cCT
 cdn


### PR DESCRIPTION
Добавил речарджеры на дельту, мету, бокс, синдибокс в отделы, куда были добавлены моды (бриг, мостик, инжа, парамедики)


Бегать каждый раз в закрытое робо, где может и не быть роботехов, отнимает много времени и не весело!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * На нескольких станциях добавлены станции подзарядки в медицинских, инженерных, командных и охранных зонах.

* **Изменения карт**
  * Обновлено размещение объектов на BoxStation и Syndicate BoxStation.
  * Скорректированы декоративные объекты и предметы на мостике, в бриге и инженерной комнате отдыха.
  * На DeltaStation и MetaStation добавлены станции подзарядки в соответствующих помещениях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->