### PR TITLE
GhostFishing Bugfix

### DIFF
--- a/modular_bluemoon/code/game/machinery/big_manipulator/manipulator_tasks.dm
+++ b/modular_bluemoon/code/game/machinery/big_manipulator/manipulator_tasks.dm
@@ -112,6 +112,8 @@
 		return FALSE
 	if(isliving(candidate))
 		return FALSE
+	if(isobserver(candidate))
+		return FALSE
 	if(isitem(candidate))
 		var/obj/item/candidate_item = candidate
 		if(candidate_item.item_flags & (ABSTRACT|DROPDEL))


### PR DESCRIPTION

## Changelog

:cl:
fix: Руки-манипуляторы перестали вылавливать гостов
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Наблюдатели больше не выбираются манипулятором в качестве объектов для захвата.
  * Сохранены существующие ограничения для других недопустимых целей.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->