### PR TITLE
donate unbalance delete

### DIFF
--- a/modular_bluemoon/fluffs/code/donator.dm
+++ b/modular_bluemoon/fluffs/code/donator.dm
@@ -2633,6 +2633,7 @@
 	path = /obj/item/clothing/mask/gas/syndicate/wypmc_gasmask
 	ckeywhitelist = list("foxrtotlimda")
 
+/*
 /datum/gear/donator/bm/atomas_fluted_armor
 	name = "Fluted Plate Armor"
 	slot = ITEM_SLOT_ICLOTHING
@@ -2644,6 +2645,25 @@
 	slot = ITEM_SLOT_HEAD
 	path = /obj/item/clothing/head/helmet/military
 	ckeywhitelist = list("atomas")
+
+/datum/gear/donator/bm/melatonin_coat
+	name = "Lycanthrope's Reinforced Coat"
+	slot = ITEM_SLOT_OCLOTHING
+	path = /obj/item/clothing/suit/armor/hos/platecarrier/melatonin
+	ckeywhitelist = list("melatonin1")
+*/
+
+/datum/gear/donator/bm/melatonin_bodysuit
+	name = "Lycanthrope's Form-Fitting Bodysuit"
+	slot = ITEM_SLOT_ICLOTHING
+	path = /obj/item/clothing/under/donator/bm/melatonin_bodysuit
+	ckeywhitelist = list("melatonin1")
+
+/datum/gear/donator/bm/melatonin_kit
+	name = "Melatonin Kit Box"
+	slot = ITEM_SLOT_BACKPACK
+	path = /obj/item/storage/box/melatonin_kit
+	ckeywhitelist = list("melatonin1")
 
 /datum/gear/donator/bm/sawwr_coat
 	name = "Dark Amber"

--- a/modular_bluemoon/fluffs/code/melatonin.dm
+++ b/modular_bluemoon/fluffs/code/melatonin.dm
@@ -397,20 +397,4 @@
 	new /obj/item/modkit/melatonin_riot_kit(src)
 	new /obj/item/modkit/melatonin_stunsword_kit(src)
 
-/datum/gear/donator/bm/melatonin_bodysuit
-	name = "Lycanthrope's Form-Fitting Bodysuit"
-	slot = ITEM_SLOT_ICLOTHING
-	path = /obj/item/clothing/under/donator/bm/melatonin_bodysuit
-	ckeywhitelist = list("melatonin1")
 
-/datum/gear/donator/bm/melatonin_coat
-	name = "Lycanthrope's Reinforced Coat"
-	slot = ITEM_SLOT_OCLOTHING
-	path = /obj/item/clothing/suit/armor/hos/platecarrier/melatonin
-	ckeywhitelist = list("melatonin1")
-
-/datum/gear/donator/bm/melatonin_kit
-	name = "Melatonin Kit Box"
-	slot = ITEM_SLOT_BACKPACK
-	path = /obj/item/storage/box/melatonin_kit
-	ckeywhitelist = list("melatonin1")


### PR DESCRIPTION
# Описание
Фиксить за печенькой не буду, но и целые наборы брони в донатных вещах видеть тоже не хочу

## Причина изменений
Запрещена броня, оружие и другие вещи влияющие на механ. игру в личном донате


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * В донаторское снаряжение добавлены «Облегающий бодисьют ликантропа» и набор Melatonin.
* **Изменения**
  * Записи для «Рифлёной брони Atomas», «Хаунскулла Atomas» и пальто Melatonin отключены и больше не доступны в донаторском снаряжении.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->