### PR TITLE
siedge fix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/siege/Inteq_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/siege/Inteq_base.dmm
@@ -627,15 +627,6 @@
 /obj/structure/frame,
 /turf/open/floor/mineral/plastitanium,
 /area/InteQ_ship/SOLVED)
-"bN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/bluemoon/inteq_forgotten_ship)
 "bO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -1438,7 +1429,14 @@
 /turf/open/floor/plasteel/dark,
 /area/InteQ_ship/ship5)
 "ei" = (
-/obj/item/toy/plush/borgplushie/meddrake,
+/obj/item/toy/plush/borgplushie/meddrake{
+	pixel_y = -10;
+	pixel_x = 8
+	},
+/obj/item/toy/plush/mothplushie{
+	pixel_y = 15;
+	pixel_x = -13
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "ej" = (
@@ -3924,7 +3922,9 @@
 "le" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
-/obj/item/toy/plush/bm/millie,
+/obj/item/toy/plush/bm/millie{
+	pixel_y = 4
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "lf" = (
@@ -4430,7 +4430,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/inteq_forgotten_ship)
 "mA" = (
-/obj/item/toy/plush/bm/zetta,
+/obj/item/toy/plush/bm/zetta{
+	pixel_x = -10
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "mB" = (
@@ -6170,9 +6172,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/InteQ_ship)
 "rn" = (
-/obj/item/toy/plush/bm/araminta,
-/obj/item/toy/plush/bm/araminta,
-/obj/item/toy/plush/bm/lissara,
+/obj/item/toy/plush/bm/araminta{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/toy/plush/bm/lissara{
+	pixel_y = -6;
+	pixel_x = 8
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "ro" = (
@@ -6615,7 +6622,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/InteQ_ship)
 "sF" = (
-/obj/item/toy/plush/borgplushie/scrubpuppy,
+/obj/item/toy/plush/borgplushie/scrubpuppy{
+	pixel_x = -8;
+	pixel_y = 5
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "sG" = (
@@ -8382,7 +8392,10 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/item/toy/plush/bm/expie,
+/obj/item/toy/plush/bm/expie{
+	pixel_x = 6;
+	pixel_y = -6
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "xY" = (
@@ -8631,7 +8644,10 @@
 	pixel_x = 4;
 	layer = 2.9
 	},
-/obj/item/toy/plush/bm/belinsky,
+/obj/item/toy/plush/bm/belinsky{
+	pixel_x = -6;
+	pixel_y = -4
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "yF" = (
@@ -10524,7 +10540,10 @@
 /turf/open/floor/plasteel/dark,
 /area/InteQ_ship)
 "DF" = (
-/obj/item/toy/plush/mal0,
+/obj/item/toy/plush/mal0{
+	pixel_x = 3;
+	pixel_y = 6
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "DG" = (
@@ -10729,7 +10748,9 @@
 /turf/open/floor/plasteel/white,
 /area/InteQ_ship)
 "El" = (
-/obj/item/toy/plush/bm/koteykomya,
+/obj/item/toy/plush/bm/koteykomya{
+	pixel_x = -10
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/InteQ_ship)
 "Em" = (
@@ -16018,6 +16039,15 @@
 /obj/structure/urinal,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/InteQ_ship)
+"TM" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/bluemoon/inteq_forgotten_ship)
 "TN" = (
 /obj/machinery/porta_turret/syndicate/pod/toolbox{
 	faction = list("InteQ")
@@ -44747,7 +44777,7 @@ pR
 pR
 Sh
 vJ
-bN
+TM
 gM
 BK
 dv

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/siege/Inteq_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/siege/Inteq_base.dmm
@@ -627,6 +627,15 @@
 /obj/structure/frame,
 /turf/open/floor/mineral/plastitanium,
 /area/InteQ_ship/SOLVED)
+"bN" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/bluemoon/inteq_forgotten_ship)
 "bO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -44738,7 +44747,7 @@ pR
 pR
 Sh
 vJ
-gM
+bN
 gM
 BK
 dv

--- a/code/controllers/subsystem/inteq_pact_siege.dm
+++ b/code/controllers/subsystem/inteq_pact_siege.dm
@@ -176,7 +176,7 @@ GLOBAL_DATUM_INIT(inteq_pact_siege, /datum/inteq_pact_siege, new)
 	return is_on_battlefield_turf(get_turf(L))
 
 /datum/inteq_pact_siege/proc/register_defender(mob/living/carbon/human/H)
-	if(QDELETED(H) || !istype(H) || !(ROLE_INTEQ in H.faction) || !(H.mind || H.last_mind))
+	if(QDELETED(H) || !istype(H) || !(ROLE_INTEQ in H.faction))
 		return
 	if(HAS_TRAIT(H, TRAIT_PACT_SIEGE_DEFENDER))
 		return

--- a/code/controllers/subsystem/inteq_pact_siege.dm
+++ b/code/controllers/subsystem/inteq_pact_siege.dm
@@ -18,8 +18,8 @@ GLOBAL_DATUM_INIT(inteq_pact_siege, /datum/inteq_pact_siege, new)
 	var/gateway_announced = FALSE
 	/// Evac timer elapsed — InteQ must launch the shuttle from the console aboard it
 	var/evac_ready = FALSE
-	var/list/datum/weakref/defenders = list()
-	var/list/datum/weakref/attackers = list()
+	var/list/defenders = list() // weakref
+	var/list/attackers = list() // weakref
 	/// Visual sync: whether station gateway was already flipped to «open» overlays
 	var/gateway_visual_open = FALSE
 	/// Round report: siege was activated this round
@@ -175,17 +175,17 @@ GLOBAL_DATUM_INIT(inteq_pact_siege, /datum/inteq_pact_siege, new)
 		return FALSE
 	return is_on_battlefield_turf(get_turf(L))
 
-/datum/inteq_pact_siege/proc/register_defender(mob/living/L)
-	if(QDELETED(L) || !(ROLE_INTEQ in L.faction))
+/datum/inteq_pact_siege/proc/register_defender(mob/living/carbon/human/H)
+	if(QDELETED(H) || !(ROLE_INTEQ in H.faction) || !(H.mind || H.last_mind))
 		return
-	if(HAS_TRAIT(L, TRAIT_PACT_SIEGE_DEFENDER))
+	if(HAS_TRAIT(H, TRAIT_PACT_SIEGE_DEFENDER))
 		return
-	ADD_TRAIT(L, TRAIT_PACT_SIEGE_DEFENDER, PACT_SIEGE_TRAIT_SOURCE)
-	ADD_TRAIT(L, TRAIT_NODISMEMBER, PACT_SIEGE_TRAIT_SOURCE)
-	defenders |= WEAKREF(L)
+	ADD_TRAIT(H, TRAIT_PACT_SIEGE_DEFENDER, PACT_SIEGE_TRAIT_SOURCE)
+	ADD_TRAIT(H, TRAIT_NODISMEMBER, PACT_SIEGE_TRAIT_SOURCE)
+	defenders |= WEAKREF(H)
 	defenders_ever_registered = TRUE
-	track_participant(L, "defender")
-	RegisterSignal(L, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(check_defender_station_breach))
+	track_participant(H, "defender")
+	RegisterSignal(H, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(check_defender_station_breach))
 
 /datum/inteq_pact_siege/proc/check_defender_station_breach(datum/source)
 	SIGNAL_HANDLER
@@ -345,9 +345,9 @@ GLOBAL_DATUM_INIT(inteq_pact_siege, /datum/inteq_pact_siege, new)
 	GLOB.the_gateway.update_appearance()
 
 /datum/inteq_pact_siege/proc/register_existing_defenders()
-	for(var/mob/living/L in GLOB.mob_living_list)
-		if(is_on_battlefield(L))
-			register_defender(L)
+	for(var/mob/living/carbon/human/H as anything in GLOB.human_list)
+		if(is_on_battlefield(H))
+			register_defender(H)
 
 /datum/inteq_pact_siege/proc/remove_inteq_spawners()
 	var/z = resolve_siege_z()

--- a/code/controllers/subsystem/inteq_pact_siege.dm
+++ b/code/controllers/subsystem/inteq_pact_siege.dm
@@ -176,7 +176,7 @@ GLOBAL_DATUM_INIT(inteq_pact_siege, /datum/inteq_pact_siege, new)
 	return is_on_battlefield_turf(get_turf(L))
 
 /datum/inteq_pact_siege/proc/register_defender(mob/living/carbon/human/H)
-	if(QDELETED(H) || !(ROLE_INTEQ in H.faction) || !(H.mind || H.last_mind))
+	if(QDELETED(H) || !istype(H) || !(ROLE_INTEQ in H.faction) || !(H.mind || H.last_mind))
 		return
 	if(HAS_TRAIT(H, TRAIT_PACT_SIEGE_DEFENDER))
 		return


### PR DESCRIPTION
# Описание
- Защитниками осады интека считаются только игроки (carbon/human)
- Добавлен морг на базу интека
- Потыкал плюшки, чтобы смотрелись красивее

## Причина изменений
Гейт не закрывался т.к. не всех мобов убивали

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Добавлен морг на базу интека (осада интека)
fix: Защитниками осады интека считаются только игроки (carbon/human)
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Игровые изменения**
  * Скорректировано размещение плюшевых игрушек на базе Inteq для более аккуратного отображения.
  * Добавлена плюшевая игрушка мотылька; одна дублирующаяся игрушка удалена.
  * В области забытого корабля добавлен морг с синей отделкой.

* **Исправления**
  * Регистрация защитников осады теперь ограничена людьми, находящимися на поле боя.
  * Уточнён состав участников осады для более корректной работы игровых событий.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->