### PR TITLE
Убрал из спавна грифозную мышь

### DIFF
--- a/modular_splurt/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/modular_splurt/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -9,7 +9,8 @@
 	maxHealth = 7
 	health = 7
 	chew_probability = 0
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN //грифозная хуйня что срёт плзамой. Из за неё один раз упал сервак. Пусть лучше это будет щитспавном
+
 
 
 /mob/living/simple_animal/mouse/boommouse/Initialize()


### PR DESCRIPTION
В экстракте ксенобио спавнилась мышь-взрывучка что срала плазмой. Не круто, грифозно

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Обычный враждебный спавн взрывающейся мыши отключён.
  * Возможность её появления через щитспавн сохранена.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->