### PR TITLE
Исправлены ошибки из жалоб игроков и уточнены описания механик

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1637,12 +1637,10 @@
 	pixel_x = -25
 	},
 /obj/item/reagent_containers/food/drinks/bottle/blank{
-	reagents = /datum/reagent/consumable/applejuice;
 	list_reagents = list(/datum/reagent/consumable/applejuice = 120);
 	pixel_x = 5
 	},
 /obj/item/reagent_containers/food/drinks/bottle/blank{
-	reagents = /datum/reagent/consumable/applejuice;
 	reagent_value = 2;
 	list_reagents = list(/datum/reagent/consumable/applejuice = 120)
 	},

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -35,6 +35,20 @@
 	difficulty = 8
 	excludefromjob = list("Captain")
 
+// Эти предметы для кражи могут появляться только в стартовой экипировке определённой профессии.
+// Проверяем при выдаче цели, чтобы учитывать предметы прибывших позже персонажей.
+/datum/objective_item/steal/traitor/ExtraCheck()
+	for(var/obj/item/candidate in world)
+		if(!istype(candidate, targetitem) || QDELETED(candidate))
+			continue
+		var/turf/item_turf = get_turf(candidate)
+		// На ЦК и в руинах есть запасы снаряжения, которое ещё не попало на станцию.
+		if(!item_turf || !is_station_level(item_turf.z))
+			continue
+		if(check_special_completion(candidate))
+			return TRUE
+	return FALSE
+
 /datum/objective_item/steal/traitor/fireaxe
 	name = "пожарный топор."
 	targetitem = /obj/item/fireaxe

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -339,7 +339,7 @@ DEFINE_BITFIELD(turret_flags, list(
 		//This code handles moving the turret around. After all, it's a portable turret!
 		if(!anchored && !isinspace())
 			setAnchored(TRUE)
-			invisibility = INVISIBILITY_MAXIMUM
+			invisibility = has_cover ? INVISIBILITY_MAXIMUM : 0
 			update_icon()
 			to_chat(user, "<span class='notice'>You secure the exterior bolts on the turret.</span>")
 			if(has_cover)
@@ -350,7 +350,7 @@ DEFINE_BITFIELD(turret_flags, list(
 			to_chat(user, "<span class='notice'>You unsecure the exterior bolts on the turret.</span>")
 			power_change()
 			invisibility = 0
-			qdel(cover) //deletes the cover, and the turret instance itself becomes its own cover.
+			QDEL_NULL(cover) // У незакреплённой турели кожух отображается спрайтом самой турели.
 
 	else if(I.GetID())
 		//Behavior lock/unlock mangement
@@ -604,7 +604,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	if(cover)
 		cover.icon_state = "turretCover"
 	raised = 0
-	invisibility = 2
+	invisibility = has_cover ? INVISIBILITY_OBSERVER : 0
 	update_icon()
 
 /obj/machinery/porta_turret/proc/assess_perp(mob/living/carbon/human/perp)

--- a/code/game/machinery/rodstopper.dm
+++ b/code/game/machinery/rodstopper.dm
@@ -1,5 +1,5 @@
 /obj/item/circuitboard/machine/rodstopper
-	name = "Rodstopper (плата машины)"
+	name = "Rodstopper (Machine Board)"
 	desc = "Плата одноразового уловителя стержня Rodstopper. Машину нужно строить прямо на пути стержня: после сборки её нельзя передвинуть или разобрать инструментами. Через пять секунд после поимки происходит опасный локальный коллапс — немедленно отойдите подальше!"
 	icon_state = "generic"
 	build_path = /obj/machinery/rodstopper

--- a/code/game/machinery/rodstopper.dm
+++ b/code/game/machinery/rodstopper.dm
@@ -1,5 +1,6 @@
 /obj/item/circuitboard/machine/rodstopper
-	name = "Rodstopper (Machine Board)"
+	name = "Rodstopper (плата машины)"
+	desc = "Плата одноразового уловителя стержня Rodstopper. Машину нужно строить прямо на пути стержня: после сборки её нельзя передвинуть или разобрать инструментами. Через пять секунд после поимки происходит опасный локальный коллапс — немедленно отойдите подальше!"
 	icon_state = "generic"
 	build_path = /obj/machinery/rodstopper
 	req_components = list(
@@ -19,6 +20,7 @@
 
 /obj/machinery/rodstopper/examine(mob/user)
 	. = ..()
+	. += span_notice("Одноразовая установка: стройте прямо на пути стержня. После сборки её нельзя передвинуть или разобрать инструментами.")
 	. += span_warning("При остановке стержня она вызовет локальный коллапс реальности - держитесь подальше!")
 
 /obj/machinery/rodstopper/Initialize(mapload)

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -85,7 +85,7 @@
 
 /obj/item/lipstick/mime
 	name = "Kiss of Mute"
-	desc = "Тихий тюбик помады. Он говорит о многом без слов."
+	desc = "Тихий тюбик помады. Наносить её может только мим. Воздушный поцелуй (*kiss) вводит углеродной цели 1 единицу Mute Toxin; контактный поцелуй через меню взаимодействий — 1–2 единицы, только при намерении навредить."
 	colour = "#808080"
 	closed_icon_state = "lipstick_mime"
 	lipstick_trait = TRAIT_KISS_MIME

--- a/code/modules/hydroponics/grown/peanuts.dm
+++ b/code/modules/hydroponics/grown/peanuts.dm
@@ -12,8 +12,8 @@
 
 /obj/item/reagent_containers/food/snacks/grown/peanut
 	seed = /obj/item/seeds/peanutseed
-	name = "peanut"
-	desc = "Peanuts for the peanut gallery!" //get me a better description, boys.
+	name = "арахис"
+	desc = "Арахис для любителей похрустеть. Сначала обжарьте или высушите его, затем измельчите в арахисовую пасту."
 	icon_state = "peanut"
 	filling_color = "#C4AE7A"
 	bitesize = 100
@@ -24,9 +24,10 @@
 	AddElement(/datum/element/dryable, /obj/item/reagent_containers/food/snacks/roasted_peanuts)
 
 /obj/item/reagent_containers/food/snacks/roasted_peanuts
-	name = "roasted peanuts"
-	desc = "A handful of roasted peanuts, with or without salt."
+	name = "жареный арахис"
+	desc = "Горсть жареного арахиса, с солью или без. Его можно измельчить в арахисовую пасту."
 	icon_state = "roasted_peanuts"
 	foodtype = VEGETABLES
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	juice_results = list(/datum/reagent/consumable/peanut_butter = 3)
+	grind_results = list(/datum/reagent/consumable/peanut_butter = 3)

--- a/code/modules/hydroponics/grown/peanuts.dm
+++ b/code/modules/hydroponics/grown/peanuts.dm
@@ -1,3 +1,5 @@
+#define ROASTED_PEANUT_BUTTER_AMOUNT 3
+
 /obj/item/seeds/peanutseed
 	name = "pack of peanut seeds"
 	desc = "These seeds grow to produce fruits botanically classified as legumes, but mundanely referred as nuts."
@@ -12,7 +14,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/peanut
 	seed = /obj/item/seeds/peanutseed
-	name = "арахис"
+	name = "peanut"
 	desc = "Арахис для любителей похрустеть. Сначала обжарьте или высушите его, затем измельчите в арахисовую пасту."
 	icon_state = "peanut"
 	filling_color = "#C4AE7A"
@@ -24,10 +26,12 @@
 	AddElement(/datum/element/dryable, /obj/item/reagent_containers/food/snacks/roasted_peanuts)
 
 /obj/item/reagent_containers/food/snacks/roasted_peanuts
-	name = "жареный арахис"
+	name = "roasted peanuts"
 	desc = "Горсть жареного арахиса, с солью или без. Его можно измельчить в арахисовую пасту."
 	icon_state = "roasted_peanuts"
 	foodtype = VEGETABLES
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
-	juice_results = list(/datum/reagent/consumable/peanut_butter = 3)
-	grind_results = list(/datum/reagent/consumable/peanut_butter = 3)
+	juice_results = list(/datum/reagent/consumable/peanut_butter = ROASTED_PEANUT_BUTTER_AMOUNT)
+	grind_results = list(/datum/reagent/consumable/peanut_butter = ROASTED_PEANUT_BUTTER_AMOUNT)
+
+#undef ROASTED_PEANUT_BUTTER_AMOUNT

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -576,6 +576,8 @@ GLOBAL_VAR_INIT(pda_messenger_directory_time, -1)
 
 	message = sanitize_pda_message(message, sender)
 	if(!message && !photo_path)
+		if(mime_mode && sender)
+			to_chat(sender, span_notice("PDA мима отправляет только эмодзи и фотографии. Выберите эмодзи кнопкой в чате или прикрепите фото; обычный текст удаляется."))
 		return FALSE
 
 	// Filter targets

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -186,6 +186,7 @@
 // #include "pills.dm"
 // #include "plantgrowth_tests.dm"
 #include "perf_log_columns.dm"
+#include "player_report_regressions.dm"
 #include "process_memory.dm"
 #include "projectiles.dm"
 #include "weather.dm"

--- a/code/modules/unit_tests/nightshift.dm
+++ b/code/modules/unit_tests/nightshift.dm
@@ -266,6 +266,15 @@
 
 	TEST_ASSERT_EQUAL(test_light.switchcount, 7, "Silent nightshift interpolation should not increment bulb aging.")
 
+/// Отмечает завершение отложенного update(0) из Initialize, сохраняя обычную инициализацию лампы.
+/obj/machinery/light/nightshift_relight_test
+	var/startup_update_complete = FALSE
+
+/obj/machinery/light/nightshift_relight_test/update(trigger = TRUE, silent = FALSE)
+	. = ..()
+	if(!trigger && !silent)
+		startup_update_complete = TRUE
+
 /datum/unit_test/nightshift_relight_resync
 	var/list/original_station_areas
 	var/list/original_apcs_list
@@ -285,7 +294,7 @@
 	SSnightshift.can_fire = FALSE
 	sleep(world.tick_lag)
 	SSnightshift.nightshift_refresh_running = FALSE
-	SSnightshift.nightshift_refresh_generation++ // Invalidate any running async refresh
+	SSnightshift.nightshift_refresh_generation++ // Отменяем незавершённое асинхронное обновление.
 	test_area = get_area(run_loc_floor_bottom_left)
 	light_turf = locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z)
 	original_station_areas = GLOB.the_station_areas.Copy()
@@ -308,13 +317,10 @@
 	test_apc.update()
 	test_area.power_light = TRUE
 	test_area.lightswitch = TRUE
-	test_light = allocate(/obj/machinery/light, light_turf)
-	// Initialize светильника отложен через spawn(2) { prob(2) break_light_tube; spawn(1) { update(0) } }.
-	// Чинит лампу код ниже, поэтому разбитие внутри этого окна безвредно - но 4 деци
-	// оставляли планировщику ровно один тик запаса: на загруженном раннере отложенная
-	// цепочка приезжала уже ПОСЛЕ ремонта, и фикстура уходила в тест разбитой, без
-	// источника света (падение "Setup should have a live light source").
-	sleep(1 SECONDS)
+	test_light = allocate(/obj/machinery/light/nightshift_relight_test, light_turf)
+	// Фиксированный sleep не гарантирует завершение вложенных spawn на загруженном CI.
+	// Ждём последний update из Initialize, чтобы случайное разбитие не произошло после ремонта.
+	TEST_ASSERT(wait_for_var(test_light, "startup_update_complete", TRUE, 5 SECONDS), "Лампа не завершила отложенную инициализацию.")
 	test_light.status = LIGHT_OK
 	test_light.on = test_light.has_power()
 	test_light.switchcount = 0
@@ -338,6 +344,8 @@
 
 /datum/unit_test/nightshift_relight_resync/proc/prime_deep_night_fixture()
 	test_light.status = LIGHT_OK
+	// update APC вызывает power_change лампы: исключаем случайное перегорание при подготовке.
+	test_light.switchcount = -1
 	test_apc.update()
 	test_light.on = test_light.has_power()
 	test_light.switchcount = 0
@@ -381,6 +389,7 @@
 	test_light.on = FALSE
 	test_light.set_light(0, l_cone_angle = 0)
 	drain_nightshift_lighting_work()
+	test_light.switchcount = -1
 	test_light.fix()
 	assert_deep_night_emission("Fixture repair")
 

--- a/code/modules/unit_tests/player_report_regressions.dm
+++ b/code/modules/unit_tests/player_report_regressions.dm
@@ -1,0 +1,163 @@
+/// Повторная установка ДНК-замка не должна менять описание шасси, в том числе после применения emag.
+/datum/unit_test/mecha_dna_lock_description/proc/operate_lock(obj/vehicle/sealed/mecha/mech, list/href_list)
+	mech.Topic(null, href_list)
+
+/datum/unit_test/mecha_dna_lock_description/Run()
+	var/obj/vehicle/sealed/mecha/working/ripley/mech = allocate(/obj/vehicle/sealed/mecha/working/ripley)
+	var/mob/living/carbon/human/pilot = allocate(/mob/living/carbon/human)
+	pilot.forceMove(mech)
+	mech.add_occupant(pilot)
+	mech.desc = "Custom chassis description."
+	var/original_description = mech.desc
+	for(var/cycle in 1 to 2)
+		pilot.name = "Test Pilot [cycle]"
+		world.PushUsr(pilot, CALLBACK(src, PROC_REF(operate_lock)), mech, list("dna_lock" = "1"))
+		TEST_ASSERT_EQUAL(mech.dna_lock, pilot.dna.unique_enzymes, "The pilot must actually set the lock")
+		TEST_ASSERT_EQUAL(mech.dna_lock_name, pilot.name, "The lock must remember its owner's name")
+		var/list/locked_examine = mech.examine(pilot)
+		var/lock_lines = 0
+		for(var/line in locked_examine)
+			if(findtext(line, "Этот мех заблокирован ДНК"))
+				lock_lines++
+		TEST_ASSERT_EQUAL(lock_lines, 1, "Examine must contain exactly one DNA lock notice")
+		TEST_ASSERT_EQUAL(mech.desc, original_description, "Locking must not edit desc")
+		world.PushUsr(pilot, CALLBACK(src, PROC_REF(operate_lock)), mech, list("reset_dna" = "1"))
+		TEST_ASSERT_NULL(mech.dna_lock, "Reset must clear the lock")
+		TEST_ASSERT_NULL(mech.dna_lock_name, "Reset must clear the display name")
+		TEST_ASSERT(!findtext(jointext(mech.examine(pilot), "\n"), "Этот мех заблокирован ДНК"), "Unlocked examine must not show a stale lock")
+	world.PushUsr(pilot, CALLBACK(src, PROC_REF(operate_lock)), mech, list("dna_lock" = "1"))
+	var/obj/item/card/emag/emag = allocate(/obj/item/card/emag)
+	mech.emag_act(pilot, emag)
+	TEST_ASSERT_NULL(mech.dna_lock_name, "Emag must also clear the display name")
+	TEST_ASSERT_EQUAL(mech.desc, original_description, "Emag must preserve unrelated custom descriptions")
+
+/datum/unit_test/portable_turret_relocation/Run()
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+	var/obj/item/wrench/wrench = allocate(/obj/item/wrench)
+	for(var/turret_type in list(/obj/machinery/porta_turret, /obj/machinery/porta_turret/syndicate, /obj/machinery/porta_turret/syndicate/energy))
+		var/obj/machinery/porta_turret/turret = allocate(turret_type)
+		// Сначала ждём завершения начальной анимации подъёма турелей без кожуха.
+		sleep(1 SECONDS)
+		turret.toggle_on(FALSE)
+		sleep(1 SECONDS)
+		if(!turret.has_cover)
+			TEST_ASSERT_EQUAL(turret.invisibility, 0, "An uncovered turret must remain visible when turned off")
+		for(var/cycle in 1 to 2)
+			turret.attackby(wrench, user)
+			TEST_ASSERT(!turret.anchored, "The disabled turret must unanchor")
+			TEST_ASSERT_NULL(turret.cover, "Unanchoring must clear the old cover reference")
+			turret.forceMove(get_step(get_turf(turret), EAST))
+			turret.attackby(wrench, user)
+			TEST_ASSERT(turret.anchored, "The relocated turret must anchor")
+			if(turret.has_cover)
+				TEST_ASSERT_NOTNULL(turret.cover, "Covered turrets must rebuild their cover")
+				TEST_ASSERT_EQUAL(get_turf(turret.cover), get_turf(turret), "The cover must follow relocation")
+			else
+				TEST_ASSERT_EQUAL(turret.invisibility, 0, "Anchoring an uncovered turret must not make it invisible")
+
+/datum/unit_test/rebar_crossbow_ammo_lifecycle/Run()
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+	for(var/crossbow_type in list(/obj/item/gun/ballistic/rebarxbow, /obj/item/gun/ballistic/rebarxbow/forced, /obj/item/gun/ballistic/rebarxbow/syndie))
+		var/obj/item/gun/ballistic/rebarxbow/crossbow = allocate(crossbow_type)
+		if(istype(crossbow, /obj/item/gun/ballistic/rebarxbow/forced))
+			var/obj/item/gun/ballistic/rebarxbow/forced/forced_crossbow = crossbow
+			forced_crossbow.can_misfire = FALSE
+		TEST_ASSERT_NOTNULL(crossbow.chambered, "Initialization must not orphan the first bolt")
+		TEST_ASSERT_EQUAL(crossbow.magazine.ammo_count() + 1, crossbow.magazine.max_ammo, "Initialization must retain all supplied bolts")
+		var/obj/item/ammo_casing/bolt = crossbow.chambered
+		crossbow.draw_time = 0
+		crossbow.shoot_with_empty_chamber(user)
+		TEST_ASSERT(!crossbow.bowstring_loose, "Trying to fire a loaded, loose crossbow must draw its bowstring")
+		crossbow.rack(user)
+		TEST_ASSERT_EQUAL(bolt.loc, get_turf(crossbow), "Loosening must drop the live bolt on the floor")
+		TEST_ASSERT_NOTNULL(bolt.BB, "The ejected bolt must remain usable")
+		TEST_ASSERT_NULL(crossbow.chambered, "The chamber must be clear after unloading")
+		// Заряжаем тот же болт и проверяем настоящий выстрел вместе с вызовом process_chamber.
+		bolt.forceMove(crossbow)
+		crossbow.chambered = bolt
+		crossbow.bowstring_loose = FALSE
+		var/reserve_ammo = crossbow.magazine.ammo_count()
+		TEST_ASSERT(crossbow.do_fire(run_loc_floor_top_right, user, FALSE), "The reloaded bolt must fire")
+		TEST_ASSERT(crossbow.bowstring_loose, "Firing must loosen the bowstring")
+		TEST_ASSERT_NULL(crossbow.chambered, "Firing must leave the chamber empty until the next draw")
+		TEST_ASSERT(QDELETED(bolt), "The spent casing must not leak inside the crossbow")
+		TEST_ASSERT_EQUAL(crossbow.magazine.ammo_count(), reserve_ammo, "Firing must not consume or seat a second bolt")
+
+/datum/unit_test/roasted_peanut_grinding/Run()
+	var/obj/machinery/reagentgrinder/grinder = allocate(/obj/machinery/reagentgrinder)
+	var/obj/item/reagent_containers/food/snacks/roasted_peanuts/peanuts = allocate(/obj/item/reagent_containers/food/snacks/roasted_peanuts, grinder)
+	grinder.holdingitems += peanuts
+	grinder.grind_item(peanuts)
+	TEST_ASSERT(abs(grinder.beaker.reagents.get_reagent_amount(/datum/reagent/consumable/peanut_butter) - 3) < 0.001, "Grinding roasted peanuts must produce 3 units of peanut butter")
+	TEST_ASSERT(QDELETED(peanuts), "Grinding must consume the peanuts")
+	peanuts = allocate(/obj/item/reagent_containers/food/snacks/roasted_peanuts, grinder)
+	grinder.holdingitems += peanuts
+	grinder.juice_item(peanuts)
+	TEST_ASSERT(abs(grinder.beaker.reagents.get_reagent_amount(/datum/reagent/consumable/peanut_butter) - 6) < 0.001, "The existing juicing recipe must remain usable")
+
+// Уникальный подтип позволяет проверять наличие предмета независимо от карты и экипировки игроков.
+/obj/item/clothing/mask/gas/mime/unit_test_theft
+
+/datum/unit_test/theft_target_availability/Run()
+	var/datum/objective_item/steal/traitor/mime_mask/objective = allocate(/datum/objective_item/steal/traitor/mime_mask)
+	objective.targetitem = /obj/item/clothing/mask/gas/mime/unit_test_theft
+	TEST_ASSERT(!objective.ExtraCheck(), "A missing job item must not be offered for theft")
+	var/list/station_levels = SSmapping.levels_by_trait(ZTRAIT_STATION)
+	TEST_ASSERT(length(station_levels), "The fixture needs a station z-level")
+	var/turf/station_turf = locate(1, 1, station_levels[1])
+	var/obj/item/storage/backpack/bag = allocate(/obj/item/storage/backpack, station_turf)
+	var/obj/item/clothing/mask/gas/mime/unit_test_theft/mask = allocate(/obj/item/clothing/mask/gas/mime/unit_test_theft, bag)
+	TEST_ASSERT(objective.ExtraCheck(), "An actual item inside station storage must be eligible without its job")
+	mask.moveToNullspace()
+	TEST_ASSERT(!objective.ExtraCheck(), "An inaccessible nullspace item must not satisfy availability")
+	var/list/centcom_levels = SSmapping.levels_by_trait(ZTRAIT_CENTCOM)
+	TEST_ASSERT(length(centcom_levels), "The fixture needs a Central Command z-level")
+	mask.forceMove(locate(1, 1, centcom_levels[1]))
+	TEST_ASSERT(!objective.ExtraCheck(), "Equipment stored at Central Command must not make a station theft available")
+	mask.forceMove(bag)
+	TEST_ASSERT(objective.ExtraCheck(), "A later arrival must become eligible without rebuilding the objective pool")
+	qdel(mask)
+	TEST_ASSERT(!objective.ExtraCheck(), "A deleted item must stop satisfying availability")
+
+/datum/unit_test/mime_pda_and_lipstick
+	var/saved_debug_signal
+
+/datum/unit_test/mime_pda_and_lipstick/Destroy()
+	if(!isnull(saved_debug_signal))
+		SSnetworks.ntnet_debug_global_signal = saved_debug_signal
+	return ..()
+
+/datum/unit_test/mime_pda_and_lipstick/Run()
+	var/mob/living/carbon/human/mime = allocate(/mob/living/carbon/human)
+	mime.mind_initialize()
+	mime.mind.miming = TRUE
+	var/obj/item/modular_computer/pda/mime/source = allocate(/obj/item/modular_computer/pda/mime)
+	var/obj/item/modular_computer/pda/target = allocate(/obj/item/modular_computer/pda)
+	var/datum/computer_file/program/messenger/source_app = locate(/datum/computer_file/program/messenger) in source.get_all_files()
+	var/datum/computer_file/program/messenger/target_app = locate(/datum/computer_file/program/messenger) in target.get_all_files()
+	TEST_ASSERT(source_app?.mime_mode, "The mime PDA must use its intentional emoji-only mode")
+	TEST_ASSERT_NOTNULL(target_app, "The target PDA needs messenger")
+	// Открытие мессенджера и выбор получателя регистрируют приложения, установленные на HDD.
+	add_messenger(source_app)
+	add_messenger(target_app)
+	var/list/emojis = get_emoji_list()
+	TEST_ASSERT(length(emojis), "At least one emoji must be available")
+	TEST_ASSERT(length(source_app.sanitize_pda_message(":[emojis[1]]:", mime)), "A miming user must be able to compose emoji messages")
+	// Используем тестовый режим NTNet, чтобы не зависеть от оборудования связи на карте.
+	saved_debug_signal = SSnetworks.ntnet_debug_global_signal
+	SSnetworks.ntnet_debug_global_signal = TRUE
+	var/datum/picture/photo = allocate(/datum/picture)
+	photo.picture_image = icon('icons/obj/items_and_weapons.dmi', "photo")
+	source.picture = photo
+	TEST_ASSERT(source_app.send_message(mime, "", list(target_app)), "A miming user must be able to send a photo without text")
+	TEST_ASSERT_NULL(source.picture, "The photo must be consumed as an attachment")
+	var/obj/item/cartridge/virus/mime/disk = source.inserted_disk
+	TEST_ASSERT(istype(disk), "The mime PDA must have its virus cartridge")
+	var/initial_charges = disk.charges
+	disk.send_virus(source, target, mime, "")
+	TEST_ASSERT_EQUAL(disk.charges, initial_charges - 1, "The virus must work without a text message")
+	TEST_ASSERT(target_app.alert_silenced, "The virus must silence the recipient PDA")
+	var/obj/item/projectile/kiss/mime/kiss = allocate(/obj/item/projectile/kiss/mime)
+	kiss.suppressed = TRUE
+	kiss.harmless_on_hit(mime)
+	TEST_ASSERT_EQUAL(mime.reagents.get_reagent_amount(/datum/reagent/toxin/mutetoxin), 1, "The mime air kiss must deliver its configured one-unit dose")

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -60,6 +60,8 @@
 	var/mecha_flags = ADDING_ACCESS_POSSIBLE | CANSTRAFE | IS_ENCLOSED | HAS_LIGHTS
 	///Stores the DNA enzymes of a carbon so tht only they can access the mech
 	var/dna_lock
+	/// Имя владельца на момент установки ДНК-замка; в desc не добавляется.
+	var/dna_lock_name
 	///Spark effects are handled by this datum
 	var/datum/effect_system/spark_spread/spark_system = new
 	///How powerful our lights are
@@ -390,6 +392,8 @@
 
 /obj/vehicle/sealed/mecha/examine(mob/user)
 	. = ..()
+	if(dna_lock)
+		. += span_notice("Этот мех заблокирован ДНК[dna_lock_name ? " - [dna_lock_name]" : ""].")
 	var/integrity = obj_integrity*100/max_integrity
 	switch(integrity)
 		if(85 to 100)
@@ -1081,7 +1085,7 @@
 	to_chat(user, "<span class='notice'>Вы замыкаете контрольную плату [src]. Блокировка ДНК снята, система управления снаряжением перекомпилирована под дополнительный слот.</span>")
 	if(dna_lock)
 		dna_lock = null
-		desc = initial(desc)
+		dna_lock_name = null
 	max_equip++
 	user.visible_message(
 		"<span class='warning'>[user] прикладывает что-то к контрольной панели [src]...</span>",

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -399,6 +399,7 @@
 		E.detach(M)
 		E.attach(N)
 	N.dna_lock = M.dna_lock
+	N.dna_lock_name = M.dna_lock_name
 	N.mecha_flags = M.mecha_flags
 	N.strafe = M.strafe
 	N.stabilizers = M.stabilizers

--- a/code/modules/vehicles/mecha/mecha_topic.dm
+++ b/code/modules/vehicles/mecha/mecha_topic.dm
@@ -439,17 +439,16 @@ function stop_updates() {
 			return
 		if(dna_lock)
 			to_chat(user, "[icon2html(src, occupants)]<span class='notice'>Эта техника уже заблокирована ДНК-замком.</span>")
+			return
 		dna_lock = user.dna.unique_enzymes
-		var/dna_lock_examine = " Этот мех заблокирован ДНК - [user.name]."
-		if(dna_lock)
-			desc += dna_lock_examine
+		dna_lock_name = user.name
 		to_chat(user, "[icon2html(src, occupants)]<span class='notice'>Вы чувствуете колкое ощущение, когда игла внутри меха берет ваш образец ДНК...</span>")
 		return
 
 	//Resets the DNA lock
 	if(href_list["reset_dna"])
-		desc = desc
 		dna_lock = null
+		dna_lock_name = null
 		return
 
 	//Repairs internal damage

--- a/modular_bluemoon/code/modules/client/loadout/uniform.dm
+++ b/modular_bluemoon/code/modules/client/loadout/uniform.dm
@@ -1,3 +1,8 @@
+/datum/gear/uniform/chronos
+	name = "Униформа New Mecca"
+	path = /obj/item/clothing/under/bm/chronos
+	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_SUITS
+
 /datum/gear/uniform/latexbodysuit
 	name = "latex bodysuit"
 	path = /obj/item/clothing/under/latex_bodysuit

--- a/modular_bluemoon/code/modules/client/loadout/uniform.dm
+++ b/modular_bluemoon/code/modules/client/loadout/uniform.dm
@@ -1,5 +1,5 @@
 /datum/gear/uniform/chronos
-	name = "Униформа New Mecca"
+	name = "New Mecca Uniform"
 	path = /obj/item/clothing/under/bm/chronos
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_SUITS
 

--- a/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
@@ -38,9 +38,11 @@
 	icon_state = "utiltan"
 
 /obj/item/clothing/under/bm/chronos
-	name = "new mecca uniform"
+	name = "униформа New Mecca"
 	desc = "In this suit, your grandfather fucked cromag."
 	icon_state = "torch_uniform"
+	mutantrace_variation = STYLE_DIGITIGRADE|USE_TAUR_CLIP_MASK|STYLE_NO_ANTHRO_ICON
+	can_adjust = FALSE
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES
 	alt_covers_chest = FALSE

--- a/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
@@ -38,7 +38,7 @@
 	icon_state = "utiltan"
 
 /obj/item/clothing/under/bm/chronos
-	name = "униформа New Mecca"
+	name = "new mecca uniform"
 	desc = "In this suit, your grandfather fucked cromag."
 	icon_state = "torch_uniform"
 	mutantrace_variation = STYLE_DIGITIGRADE|USE_TAUR_CLIP_MASK|STYLE_NO_ANTHRO_ICON

--- a/modular_bluemoon/code/modules/projectiles/ammunition/ballistic/rebar.dm
+++ b/modular_bluemoon/code/modules/projectiles/ammunition/ballistic/rebar.dm
@@ -51,8 +51,8 @@
 	custom_materials = null
 
 /obj/item/ammo_casing/rebar/nitrium
-	name = "nitrium crystal bolt"
-	desc = "A rod tipped with nitrium crystal. Delivers a sharp stimulant payload on hit."
+	name = "болт с кристаллом Nitrium"
+	desc = "Болт с наконечником из кристалла Nitrium. При попадании вводит стимулятор, но также наносит колотую рану и может застрять в теле, причиняя боль."
 	icon_state = "Nitrium crystal bolt"
 	projectile_type = /obj/item/projectile/bullet/rebar/nitrium
 	custom_materials = null

--- a/modular_bluemoon/code/modules/projectiles/ammunition/ballistic/rebar.dm
+++ b/modular_bluemoon/code/modules/projectiles/ammunition/ballistic/rebar.dm
@@ -51,7 +51,7 @@
 	custom_materials = null
 
 /obj/item/ammo_casing/rebar/nitrium
-	name = "болт с кристаллом Nitrium"
+	name = "nitrium crystal bolt"
 	desc = "Болт с наконечником из кристалла Nitrium. При попадании вводит стимулятор, но также наносит колотую рану и может застрять в теле, причиняя боль."
 	icon_state = "Nitrium crystal bolt"
 	projectile_type = /obj/item/projectile/bullet/rebar/nitrium

--- a/modular_bluemoon/code/modules/projectiles/guns/ballistic/rebarxbow.dm
+++ b/modular_bluemoon/code/modules/projectiles/guns/ballistic/rebarxbow.dm
@@ -24,7 +24,6 @@
 /obj/item/gun/ballistic/rebarxbow/Initialize(mapload)
 	. = ..()
 	bowstring_loose = TRUE
-	chambered = null
 
 /obj/item/gun/ballistic/rebarxbow/attackby(obj/item/A, mob/user, params)
 	if(!bowstring_loose)
@@ -51,7 +50,11 @@
 		draw_bowstring(user)
 		return
 	bowstring_loose = TRUE
-	chambered = null
+	if(chambered?.BB)
+		chambered.forceMove(drop_location())
+		chambered = null
+	else
+		QDEL_NULL(chambered)
 	if(user)
 		balloon_alert(user, "bowstring loosened")
 	playsound(src, 'sound/weapons/shotgunpump.ogg', 60, 1)
@@ -80,6 +83,10 @@
 	..()
 	rack(user)
 
+/obj/item/gun/ballistic/rebarxbow/process_chamber(mob/living/user, empty_chamber = TRUE)
+	// Следующий болт подаётся только при натяжении тетивы, а не сразу после выстрела.
+	return
+
 /obj/item/gun/ballistic/rebarxbow/can_shoot()
 	if(bowstring_loose || !chambered?.BB)
 		return FALSE
@@ -87,14 +94,14 @@
 
 /obj/item/gun/ballistic/rebarxbow/shoot_with_empty_chamber(mob/living/user)
 	if(chambered && !chambered.BB)
-		chambered = null
+		QDEL_NULL(chambered)
+	if(bowstring_loose && (chambered?.BB || magazine?.ammo_count()))
+		draw_bowstring(user)
+		return
 	if(chambered?.BB)
 		return ..()
 	if(!magazine || !magazine.ammo_count())
 		return ..()
-	if(bowstring_loose)
-		draw_bowstring(user)
-		return
 	chamber_round()
 	if(chambered?.BB)
 		balloon_alert(user, "bolt seated")
@@ -107,7 +114,7 @@
 
 /obj/item/gun/ballistic/rebarxbow/update_overlays()
 	. = ..()
-	if(!magazine || !magazine.ammo_count(0))
+	if(!chambered?.BB && (!magazine || !magazine.ammo_count(0)))
 		. += "[initial(icon_state)]_empty"
 	if(!bowstring_loose)
 		. += "[initial(icon_state)]_bolt_locked"


### PR DESCRIPTION
# Описание

Исправлены подтверждённые ошибки из жалоб игроков: отображение New Mecca, ДНК-лок мехов, потеря болтов, невидимость турелей и выдача целей на отсутствующие предметы. Дополнены рецепты обработки арахиса и подсказки к неочевидным механикам

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера.

## Причина изменений

Часть жалоб подтвердилась, часть касается существующих ограничений и баланса. Урон болтов Nitrium, дозировка Mute Toxin, ограничения мима и стационарность Rodstopper сохранены. Там, где не хватало объяснений, добавлены подсказки

## Changelog

:cl:
fix: Униформа New Mecca корректно отображается у дигитиградных персонажей; отключён неподдерживаемый приспущенный вариант.
add: Униформа New Mecca добавлена в лодаут.
fix: Описание ДНК-лока меха больше не дублируется и исчезает после сброса или применения emag.
fix: Арбалеты больше не теряют болты при разрядке и сохраняют запасные боеприпасы после выстрела.
fix: Турели без кожуха больше не становятся невидимыми после отключения и повторного закрепления.
fix: Новые цели кражи выдаются только при наличии подходящего предмета на станции; запасы ЦК и руин не учитываются.
qol: Жареный арахис теперь даёт пасту при измельчении; прежний способ через отжим сохранён.
qol: Добавлены пояснения к Rodstopper, болтам Nitrium, помаде Kiss of Mute и ограничениям сообщений на PDA мима.
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
  - Добавлена униформа New Mecca в набор экипировки.
  - Мехи теперь показывают имя владельца ДНК-замка.
  - Жареный арахис можно измельчать в арахисовую пасту.
  - Арбалет корректнее обрабатывает болты при ослаблении тетивы.

- **Исправления**
  - Портативные турели остаются видимыми без укрытия.
  - Цели кражи выдаются только при наличии предмета на станции.
  - Мим получает уведомление при отправке пустого сообщения.

- **Локализация и документация**
  - Обновлены описания арахиса, боеприпасов, Rodstopper и помады «Kiss of Mute».
  - Добавлены пояснения к эффектам помады и одноразового уловителя стержня.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->