### PR TITLE
nuclear disk suicide updt

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -773,7 +773,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 /obj/item/disk/nuclear/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is going delta! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	playsound(src, 'sound/machines/alarm.ogg', 50, -1, TRUE)
+	playsound(src, 'sound/machines/alarm.ogg', 80, -1, FALSE)
 	for(var/i in 1 to 100)
 		addtimer(CALLBACK(user, TYPE_PROC_REF(/atom, add_atom_colour), (i % 2)? "#00FF00" : "#FF0000", ADMIN_COLOUR_PRIORITY), i)
 	addtimer(CALLBACK(src, PROC_REF(manual_suicide), user), 101)
@@ -782,8 +782,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 /obj/item/disk/nuclear/proc/manual_suicide(mob/living/user)
 	user.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
 	user.visible_message("<span class='suicide'>[user] is destroyed by the nuclear blast!</span>")
-	user.adjustOxyLoss(200)
-	user.death(0)
+	user.gib(TRUE, drop_items = TRUE)
 
 /obj/item/disk/nuclear/fake
 	fake = TRUE

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -791,7 +791,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	name = "cheap plastic imitation of the nuclear authentication disk"
 	desc = "How anyone could mistake this for the real thing is beyond you."
 	stationloving = FALSE
-	resistance_flags = NONE
+	resistance_flags = FLAMMABLE
 	armor = null
 
 /obj/item/disk/nuclear/fake/obvious/mail

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -1,6 +1,6 @@
 //This is the proc for gibbing a mob. Cannot gib ghosts.
 //added different sort of gibs and animations. N
-/mob/proc/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
+/mob/proc/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion, drop_items = FALSE)
 	return
 
 //This is the proc for turning a mob into ash. Mostly a copy of gib code (above).

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -17,7 +17,7 @@
 	if(SSticker.mode)
 		SSticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
-/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
+/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion, drop_items = FALSE)
 	var/atom/Tsec = drop_location()
 	for(var/mob/M in src)
 		if(M in stomach_contents)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,10 +1,14 @@
-/mob/living/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
+/mob/living/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion, drop_items = FALSE)
 	var/prev_lying = lying
 	if((stat != DEAD) || istype(src, /mob/living/silicon/robot))	// Robot's death() proc is called even if he's dead on gib()
 		death(1)
 
 	if(!prev_lying)
 		gib_animation()
+
+	if(drop_items)
+		unequip_everything()
+		dust_spill_everything()
 
 	spill_organs(no_brain, no_organs, no_bodyparts, was_explosion)
 
@@ -74,6 +78,7 @@
 			LB.embedded_objects -= I
 			I.unembedded()
 			I.forceMove(T)
+			I.randomize_pixel_position(src)
 		LB.embedded_objects.Cut()
 
 	if(!C.has_embedded_objects())
@@ -86,13 +91,19 @@
 	for(var/obj/item/implant/IM as anything in implants_copy)
 		for(var/obj/item/IT in IM.contents)
 			IT.forceMove(T)
-		C.implants -= IM
-		IM.forceMove(T)
+		IM.removed(C)
+		var/obj/item/implantcase/case = new(T)
+		IM.forceMove(case)
+		case.imp = IM
+		case.name = "[case.name] ([IM.name])"
+		case.update_appearance()
+		case.randomize_pixel_position(src)
 
 	//Проглоченное (содержимое органов, например желудка)
 	for(var/obj/item/organ/O as anything in C.internal_organs)
 		for(var/obj/item/IT in O.contents)
 			IT.forceMove(T)
+			IT.randomize_pixel_position(src)
 /// BLUEMOON ADD END
 
 /mob/living/proc/dust_animation()

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -296,7 +296,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 /mob/living/simple_animal/hostile/guardian/wave_ex_act(power, datum/wave_explosion/explosion, dir)
 	adjustBruteLoss(EXPLOSION_POWER_STANDARD_SCALE_MOB_DAMAGE(power, explosion.mob_damage_mod * 0.33))
 
-/mob/living/simple_animal/hostile/guardian/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
+/mob/living/simple_animal/hostile/guardian/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion, drop_items = FALSE)
 	if(summoner)
 		to_chat(summoner, "<span class='danger'><B>Your [src] was blown up!</span></B>")
 		if(was_randomized)

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -88,7 +88,7 @@
 	return iswallturf(T)
 
 
-/mob/living/simple_animal/hostile/gorilla/gib(no_brain)
+/mob/living/simple_animal/hostile/gorilla/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion, drop_items = FALSE)
 	if(!no_brain)
 		var/mob/living/brain/B = new(drop_location())
 		B.name = real_name

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -424,7 +424,7 @@
 					to_chat(client, span_userdanger("Здесь слишком горячо!"))
 		// BLUEMOON ADD END
 
-/mob/living/simple_animal/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
+/mob/living/simple_animal/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion, drop_items = FALSE)
 	if(butcher_results || guaranteed_butcher_results)
 		var/list/butcher = list()
 		if(butcher_results)

--- a/code/modules/unit_tests/round_10150_regressions.dm
+++ b/code/modules/unit_tests/round_10150_regressions.dm
@@ -61,7 +61,9 @@
 	dummy.dust_spill_everything()
 
 	TEST_ASSERT_EQUAL(LAZYLEN(dummy.implants), 0, "имплант обязан быть снят со списка")
-	TEST_ASSERT_EQUAL(implant.loc, get_turf(dummy), "имплант обязан выпасть на пол")
+	TEST_ASSERT_EQUAL(implant.loc.type, /obj/item/implantcase)
+	TEST_ASSERT(istype(implant.loc, /obj/item/implantcase), "имплант обязан быть в кейсе")
+	TEST_ASSERT_EQUAL(implant.loc?.loc, get_turf(dummy), "имплант обязан выпасть на пол")
 
 /// "destroy proc was called multiple times" у сборного модуля брони МОДа:
 /// его on_uninstall() звал qdel(src), а Destroy() снова заходил в uninstall().

--- a/code/modules/unit_tests/round_10150_regressions.dm
+++ b/code/modules/unit_tests/round_10150_regressions.dm
@@ -61,7 +61,6 @@
 	dummy.dust_spill_everything()
 
 	TEST_ASSERT_EQUAL(LAZYLEN(dummy.implants), 0, "имплант обязан быть снят со списка")
-	TEST_ASSERT_EQUAL(implant.loc.type, /obj/item/implantcase)
 	TEST_ASSERT(istype(implant.loc, /obj/item/implantcase), "имплант обязан быть в кейсе")
 	TEST_ASSERT_EQUAL(implant.loc?.loc, get_turf(dummy), "имплант обязан выпасть на пол")
 

--- a/code/modules/unit_tests/round_10150_regressions.dm
+++ b/code/modules/unit_tests/round_10150_regressions.dm
@@ -61,8 +61,9 @@
 	dummy.dust_spill_everything()
 
 	TEST_ASSERT_EQUAL(LAZYLEN(dummy.implants), 0, "имплант обязан быть снят со списка")
-	TEST_ASSERT(istype(implant.loc, /obj/item/implantcase), "имплант обязан быть в кейсе")
-	TEST_ASSERT_EQUAL(implant.loc?.loc, get_turf(dummy), "имплант обязан выпасть на пол")
+	var/obj/item/implantcase/case = implant.loc
+	TEST_ASSERT(istype(case), "имплант обязан быть в кейсе")
+	TEST_ASSERT_EQUAL(case, get_turf(dummy), "имплант обязан выпасть на пол")
 
 /// "destroy proc was called multiple times" у сборного модуля брони МОДа:
 /// его on_uninstall() звал qdel(src), а Destroy() снова заходил в uninstall().

--- a/modular_bluemoon/code/datums/traits/negative/onelife_quirk.dm
+++ b/modular_bluemoon/code/datums/traits/negative/onelife_quirk.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(onelife_death_forms, init_onelife_death_forms())
 		return
 	H.dust(TRUE, TRUE)
 
-/mob/living/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
+/mob/living/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion, drop_items = FALSE)
 	if(HAS_TRAIT(src, TRAIT_ONELIFE))
 		onelife_crumble(src)
 		return


### PR DESCRIPTION
# Описание
Улучшил суицид от ядерного диска, теперь он гибает (с сохранением вещей)

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
refactor: Улучшен суицид от ядерного диска, теперь он гибает (с сохранением вещей)
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * При ручном самоубийстве ядерный диск теперь гиббит персонажа, а экипировка и предметы выпадают.
  * Предметы, извлечённые при гиббании, получают случайное расположение; импланты помещаются в отдельные кейсы.

* **Изменения**
  * Звук тревоги при активации самоубийства стал громче, но распространяется на меньшую дальность.
  * Поддельный очевидный ядерный диск теперь можно поджечь.

* **Исправления**
  * Исправлена обработка имплантов при гиббании: они корректно помещаются в кейсы, которые выпадают на пол.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->