### PR TITLE
TGUI для кляпов и уровни депривации голоса

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -435,3 +435,12 @@
 #define PAIN_LOW 1 // TRAIT_BLUEMOON_HIGH_PAIN_THRESHOLD
 #define PAIN_MEDIUM 2 // drunkenness
 #define PAIN_FULL 3
+
+// Уровни искажения речи (текста) в проценте если рот прикрыт
+#define MUFFLE_NONE 0 // Нет искажений
+#define MUFFLE_LOW 45 // Речь разборчивая, но приглушенная
+#define MUFFLE_MEDIUM 75 // Явно невнятная, слова узнаваемы
+#define MUFFLE_HIGH 90 // Почти не разборчиво
+
+// Специальная константа для полной немоты
+#define MUFFLE_MUTE 255 // Запрещает издавать любые звуки

--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -371,3 +371,6 @@ GLOBAL_LIST_INIT(colors_ru, list(
 	"cyan" = "циановый",
 	"white" = "белый",
 ))
+
+// Список гласных для обработки приглушённой речи (английский и русский)
+GLOBAL_LIST_INIT(vowels_for_muffledspeech, list("a", "e", "i", "o", "u", "y", "а", "е", "ё", "и", "о", "у", "ы", "э", "ю", "я"))

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -15,6 +15,44 @@
 	. = ..()
 	AddComponent(/datum/component/latex_lockable)
 
+/obj/item/clothing/mask/muzzle/attack_self(mob/user)
+	if(!user)
+		return FALSE
+	interact(user)
+	return TRUE
+
+/obj/item/clothing/mask/muzzle/interact(mob/user)
+	return ui_interact(user)
+
+/obj/item/clothing/mask/muzzle/ui_state(mob/user)
+	return GLOB.hands_state
+
+/obj/item/clothing/mask/muzzle/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "LewdDeprivation", name)
+		ui.open()
+
+/obj/item/clothing/mask/muzzle/ui_data(mob/user)
+	var/list/data = list()
+	data["mute"] = mute
+	data["levels"] = list(
+		list("value" = MUFFLE_NONE, "label" = "Свободно", "desc" = ""),
+		list("value" = MUFFLE_LOW, "label" = "Мягкая", "desc" = ""),
+		list("value" = MUFFLE_MEDIUM, "label" = "Средняя", "desc" = ""),
+		list("value" = MUFFLE_HIGH, "label" = "Сильная", "desc" = ""),
+		list("value" = MUFFLE_MUTE, "label" = "Мут", "desc" = "Никаких звуков вообще")
+	)
+	return data
+
+/obj/item/clothing/mask/muzzle/ui_act(action, params)
+	if(..())
+		return
+	switch(action)
+		if("set_mute")
+			mute = text2num(params["level"])
+			. = TRUE
+
 /obj/item/clothing/mask/muzzle/attack_paw(mob/user, act_intent, attackchain_flags)
     if(iscarbon(user))
         var/mob/living/carbon/C = user

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -9,6 +9,7 @@
 	equip_delay_other = 20
 	equip_delay_self = 20
 	mutantrace_variation = STYLE_MUZZLE
+	var/mute = MUFFLE_MUTE
 
 /obj/item/clothing/mask/muzzle/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -331,7 +331,14 @@
 	loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
 
 /mob/living/carbon/is_muzzled()
-	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
+	return get_muzzle_strength() == MUFFLE_MUTE
+
+/mob/living/carbon/get_muzzle_strength()
+	if(src.wear_mask && istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
+		var/obj/item/clothing/mask/muzzle/M = src.wear_mask
+		return M.mute
+
+	return MUFFLE_NONE
 
 /mob/living/carbon/hallucinating()
 	if(hallucination)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -296,6 +296,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(length(message) && message[1] != "!")
 		message = treat_message(message, language) // unfortunately we still need this
+
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
 	if (sigreturn & COMPONENT_UPPERCASE_SPEECH)
 		message = uppertext(message)
@@ -343,6 +344,11 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		message_range = 1
 	if(radio_return & NOPASS)
 		return TRUE
+
+	// Обработка искажения речи от масок
+	var/muzzle_strength = src.get_muzzle_strength()
+	if(muzzle_strength > 0 && !is_visual_language && !src.is_muzzled())
+		message = muffledspeech(message, muzzle_strength)
 
 	//No screams in space, unless you're next to someone.
 	var/turf/T = get_turf(src)
@@ -731,6 +737,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			. = "stammers"
 		else if(derpspeech)
 			. = "gibbers"
+		else if(get_muzzle_strength() > 0 && get_muzzle_strength() != MUFFLE_MUTE)
+			. = "mumbles"
 		// Skyrat edits
 		else if(message_mode == MODE_SING)
 			. = verb_sing

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -345,11 +345,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(radio_return & NOPASS)
 		return TRUE
 
-	// Обработка искажения речи от масок
-	var/muzzle_strength = src.get_muzzle_strength()
-	if(muzzle_strength > 0 && !is_visual_language && !src.is_muzzled())
-		message = muffledspeech(message, muzzle_strength)
-
 	//No screams in space, unless you're next to someone.
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/environment = T.return_air()
@@ -679,6 +674,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			message = machine_slur(message, replace_characters, slurring * 1.5)
 		else
 			message = slur(message,slurring)
+
+	// Обработка искажения речи от масок
+	var/muzzle_strength = get_muzzle_strength()
+	if(muzzle_strength > 0 && !src.is_muzzled())
+		message = muffledspeech(message, muzzle_strength)
+
 	// BLUEMOON EDIT END
 
 	if(cultslurring)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -717,6 +717,9 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 /mob/proc/is_muzzled()
 	return FALSE
 
+/mob/proc/get_muzzle_strength()
+	return MUFFLE_NONE
+
 /// Adds this list to the output to the stat browser
 /mob/proc/get_status_tab_items()
 	. = list()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -253,6 +253,86 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		. += letter
 	return copytext_char(sanitize(.),1,MAX_MESSAGE_LEN)
 
+/proc/muffledspeech(message, strength = 100)
+	// Сила искажения текста в процентах (0-100)
+	strength = max(0, min(100, strength))
+	if(strength <= 0)
+		return message
+
+	message = html_decode(message)
+
+	var/final_text = ""
+	var/current_word = ""
+
+	// copytext_char для корректной работы с Unicode
+	for(var/i = 1, i <= length_char(message), i++)
+		var/ch = copytext_char(message, i, i+1)
+
+		// Является ли символ разделителем? (пробел, тире, знаки препинания)
+		if(ch in list(" ", "-", "\t", "!", "?", ".", ","))
+			// Прежде чем добавить разделитель, процессим слово
+			if(length(current_word) > 0)
+				current_word = muffledword(current_word, strength)
+				final_text += current_word
+				current_word = ""
+
+			// Оставляем разделитель без изменений и сохраняем структуру речи
+			final_text += ch
+		else
+			// Добавляем букву для обработки слова
+			current_word += ch
+
+	// Не забываем обработать последнее слово в конце
+	if(length(current_word) > 0)
+		current_word = muffledword(current_word, strength)
+		final_text += current_word
+
+	return sanitize(final_text)
+
+/proc/muffledword(word, strength)
+	// Обработка слова и возврат искажённой версии: чем выше strength, тем больше скремблирования
+	var/leng = length_char(word)
+
+	// Короткие слова (1-3 символа) = более агрессивная обработка
+	if(leng <= 3)
+		return muffle_small_word(word, strength)
+
+	var/result = ""
+	for(var/i = 1, i <= leng, i++)
+		var/ch = copytext_char(word, i, i+1)
+
+		if(prob(strength))
+			if(lowertext(ch) in GLOB.vowels_for_muffledspeech)
+				result += "пф"
+			else
+				result += "м"
+		else
+			result += ch
+
+	return result
+
+/proc/muffle_small_word(word, strength)
+	// Для коротких слов (1-3 символа): случайно заменяем слово или добавляем префикс/суффикс к нему в зависимости от рандома
+
+	var/scrambled = ""
+	for(var/i = 1, i <= length_char(word), i++)
+		var/ch = copytext_char(word, i, i+1)
+
+		if(prob(strength))
+			if(lowertext(ch) in GLOB.vowels_for_muffledspeech)
+				scrambled += "пф"
+			else
+				scrambled += "м"
+		else
+			scrambled += ch
+
+	// 40% шанс полностью заменить, 60% сохранить с добавлением префикса/суффикса
+	if(prob(40))
+		return pick(scrambled, "м", "пф")
+	else
+		var/addition = pick("м", "пф", "мпф", "пфм")
+		return pick("[addition][word]", "[word][addition]")
+
 /proc/shake_camera(mob/M, duration, strength=1)
 	set waitfor = FALSE
 	if(!M || !M.client || duration <= 0)

--- a/modular_splurt/code/modules/clothing/masks/miscellaneous.dm
+++ b/modular_splurt/code/modules/clothing/masks/miscellaneous.dm
@@ -170,6 +170,7 @@
 	anthro_mob_worn_overlay = 'modular_splurt/icons/mob/clothing/mask_muzzle.dmi'
 	icon_state = "ballgag"
 	item_state = "ballgag"
+	mute = MUFFLE_MEDIUM
 
 /obj/item/clothing/mask/ninja_replica
 	name = "Replica Ninja Mask"

--- a/tgui/packages/tgui/interfaces/LewdDeprivation.js
+++ b/tgui/packages/tgui/interfaces/LewdDeprivation.js
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+import { useBackend } from '../backend';
+import { Button, Grid, Section, Stack, Tooltip } from '../components';
+import { Window } from '../layouts';
+
+export const LewdDeprivationContent = (props) => {
+  const { act, data } = useBackend();
+  const { mute, levels } = data;
+
+  return (
+    <Section scrollable>
+      <Stack vertical fill>
+        <Stack.Item grow basis={0}>
+          <Section title="Депривация" fill>
+            <Grid mt={0.6}>
+              <Grid.Column>
+                <b>Голос</b>
+              </Grid.Column>
+            </Grid>
+
+            {levels.map((level) => (
+              <Grid mt={0.2}>
+                <Stack>
+                  <Stack.Item grow>
+                    <Tooltip content={`${level.desc || `${level.value}% речи неразборчиво`}`}>
+                      <Button
+                        fluid
+                        icon={"check"}
+                        color={mute === level.value ? "green" : "default"}
+                        onClick={() => act('set_mute', { level: level.value })}>
+                        {level.label}
+                      </Button>
+                    </Tooltip>
+                  </Stack.Item>
+                </Stack>
+              </Grid>
+            ))}
+          </Section>
+        </Stack.Item>
+      </Stack>
+    </Section>
+  );
+};
+
+const BASE_HEIGHT = 230;
+const HEIGHT_PER_BUTTON = 20;
+
+export const LewdDeprivation = (props) => {
+  const { act, data, windowTitle } = useBackend();
+  const [height] = useState(() => {
+    if (!data.dynamic_window_size) {
+      return BASE_HEIGHT;
+    }
+    // Высота на основе количества опций
+    const enabledButtonsCount = Array.isArray(data.levels) ? data.levels.length : 4;
+    return BASE_HEIGHT + enabledButtonsCount * HEIGHT_PER_BUTTON;
+  });
+
+  return (
+    <Window width={200} height={height} title={windowTitle}>
+      <Window.Content>
+        <LewdDeprivationContent />
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
# Описание

На кляпы добавлен TGUI интерфейс для управления уровнями депривации голоса. Теперь можно выбрать степень ограничения речи от полной свободы до полной тишины.
Добавлена соответствующая обработка речи в код.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений

Нельзя говорить если рот заткнули, хотя технически ограничение должно быть динамичным и для РП ситуаций текущее обновление подходит больше.

## Демонстрация изменений

<img width="206" height="236" alt="image" src="https://github.com/user-attachments/assets/dd8dfc11-b844-4680-8e51-68d3d678d361" />

## Changelog

:cl:
code_imp: Добавлен сопутствующий код и TGUI интерфейс для кляпов для управления уровнями ограничения речи
code: Реализована логика обработки речи в зависимости от уровня кляпа
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
  - Добавлена настройка уровня приглушения речи для намордников: от отсутствия искажения до полной немоты.
  - Намордники могут искажать произносимые сообщения, сохраняя их структуру.
  - Добавлен интерфейс выбора текущего уровня приглушения.
  - Балдахин по умолчанию использует средний уровень приглушения.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->