### PR TITLE
[HOTFIX] Поправка путей карт .json рандомизации боксов

### DIFF
--- a/_maps/boxstation_variants_rand.json
+++ b/_maps/boxstation_variants_rand.json
@@ -1,9 +1,9 @@
 {
-    "map_name": "Box Station (Random)",
+    "map_name": "Box Stations",
     "map_path": "map_files/BoxStations",
     "map_file": "BoxStation.dmm",
     "map_variants": [
         "_maps/boxstation.json",
-        "_maps/syndicatestation.json"
+        "_maps/peacesyndicatestation.json"
     ]
 }


### PR DESCRIPTION
# Описание
- Замена `"_maps/syndicatestation.json"` на `"_maps/peacesyndicatestation.json"` чтобы выпадала корректная мирная карта, а не аплинковская.
- Замена названия в скобках на более лаконичный плюратив по английскому.

## Причина изменений
- Проёб нейминга, который я писал от руки. Лучше бы поручил ИИ.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Исправлен выбор между Бокс Стейшеном: вместо аплинк-версии Синди-станции будет появляться корректный Peace Syndie вариант.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Изменения**
  - Обновлено отображаемое название варианта карты: «Box Station (Random)» заменено на «Box Stations».
  - В список вариантов карты добавлена станция «Peace Syndicate» вместо «Syndicate Station».

<!-- end of auto-generated comment: release notes by coderabbit.ai -->