### PR TITLE
Hotfix спрайта магазина для ACRM

### DIFF
--- a/modular_bluemoon/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/modular_bluemoon/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -44,10 +44,6 @@
 	caliber = "a762x39"
 	max_ammo = 25
 
-/obj/item/ammo_box/magazine/acrm/update_icon_state()
-	..()
-	icon_state = "[initial(icon_state)]-[ammo_count() ? "30" : "0"]"
-
 /obj/item/ammo_box/magazine/acrm/empty
 	start_empty = TRUE
 


### PR DESCRIPTION
# Описание
Фикс моей недоработки.
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [x] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений
Не отображался магазин. Теперь отображается.

## Демонстрация изменений
N/a
## Changelog
:cl:
fix: ACRM mag sprite now visible again.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Магазины ACRM теперь используют базовое обновление состояния иконки без отображения уровня оставшихся патронов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->