### PR TITLE
Devourer & Revenant disease fix

### DIFF
--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -1,7 +1,7 @@
 /datum/disease/revblight
 	name = "Unnatural Wasting"
 	max_stages = 5
-	stage_prob = 10
+	stage_prob = 2
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	cure_text = "Holy water or extensive rest."
 	spread_text = "A burst of unholy energy"

--- a/modular_bluemoon/code/datums/traits/good/devourer_quirk.dm
+++ b/modular_bluemoon/code/datums/traits/good/devourer_quirk.dm
@@ -62,16 +62,6 @@
 /datum/quirk/bluemoon_devourer/proc/on_examine_holder(atom/examine_target, mob/living/carbon/human/examiner, list/examine_list)
 	examine_list += "[quirk_holder.ru_ego(TRUE)] явно мучает голод."
 
-
-/datum/quirk/bluemoon_devourer/proc/update_size_modifiers(new_size, cur_size)
-	if (check_mob_size() && new_size != cur_size) // не даём уменьшиться, в т.ч. если мёртв
-		var/mob/living/carbon/human/H= quirk_holder
-
-		var/user_slowdown = (abs(new_size - 1) * CONFIG_GET(number/body_size_slowdown_multiplier))
-
-		H.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/devourer_quirk_boost, TRUE, user_slowdown * -0.8) // убираем 80% от замедления
-
-
 /datum/quirk/bluemoon_devourer/proc/check_mob_size()
 	if(!isliving(quirk_holder))
 		return FALSE
@@ -92,7 +82,7 @@
 	if(comp)
 		qdel(comp)
 	// конец участка
-	update_size_modifiers(get_size(H), 1)
+	check_mob_size()
 
 /*
 Действия

--- a/modular_bluemoon/code/modules/mob/living/living.dm
+++ b/modular_bluemoon/code/modules/mob/living/living.dm
@@ -26,7 +26,10 @@
 	// Штраф кратен тику. Цена шага всё равно выравнивается по тику, поэтому
 	// дробная добавка либо пропала бы целиком, либо наугад превратилась бы в
 	// целый тик - лестница в тиках делает ступени предсказуемыми.
-	var/slowdown = movement_weight_slowdown(anchor_ticks, cancel_deviation, current_size, CONFIG_GET(number/body_size_slowdown_multiplier), world.tick_lag)
+	var/t_lag = world.tick_lag
+	var/slowdown = movement_weight_slowdown(anchor_ticks, cancel_deviation, current_size, CONFIG_GET(number/body_size_slowdown_multiplier), t_lag)
+	if(slowdown > 0 && HAS_TRAIT(src, TRAIT_BLUEMOON_DEVOURER))
+		movement_quantize_slowdown(slowdown*0.2, t_lag) // убираем 80% от замедления
 
 	if(slowdown > 0)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/heavy_weight_slowdown, TRUE, slowdown)

--- a/modular_sand/code/modules/mob/living/living.dm
+++ b/modular_sand/code/modules/mob/living/living.dm
@@ -23,11 +23,6 @@
 	adjust_mobsize(new_size)
 
 	update_weight(mob_weight) //BLUEMOON ADD PLACEHOLDER стоило-бы развить тему возможности изменить вес, но пока это лишь вот так
-	// BLUEMOON ADDITION AHEAD - вызов проверки на размер у персонажа
-	if(HAS_TRAIT(src, TRAIT_BLUEMOON_DEVOURER))
-		for(var/datum/quirk/bluemoon_devourer/quirk in roundstart_quirks)
-			quirk.update_size_modifiers(new_size, cur_size)
-	// BLUEMOON ADDITION END
 
 	SEND_SIGNAL(src, COMSIG_MOB_RESIZED, new_size, cur_size)
 	return TRUE


### PR DESCRIPTION
# Описание
- Исправлен баг огромного мувспида с квирком пожиратель
- Исправлен баг вечно растущего спрайта при актуализации с квирком пожиратель
- Исправлена неадекватно быстрое развитие проклятие от ревенанта

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Исправлен баг огромного мувспида с квирком пожиратель
fix: Исправлен баг вечно растущего спрайта при актуализации с квирком пожиратель
fix: Исправлена неадекватно быстрое развитие проклятие от ревенанта
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Изменения игрового процесса**
  - Прогрессирование болезни «Погибельный мор» замедлено: вероятность перехода на следующую стадию снижена.
  - Для квирка «Пожиратель» гарантирован минимальный размер персонажа 2.
  - Замедление передвижения от веса для «Пожирателей» уменьшено на 80%.
  - Изменения размера больше не применяют отдельные корректирующие модификаторы скорости для этого квирка.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->