### PR TITLE
Уменьшено макс кол-во боксов подряд до одного

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -18,7 +18,7 @@ endmap
 map boxstation_variants_rand
 ##maxplayers 70
 ##max_round_search_span 6
-##max_rounds_played 2
+##max_rounds_played 1
 endmap
 
 map metastation


### PR DESCRIPTION
# Описание
- `max_rounds_played 2` --> `max_rounds_played 1`

## Причина изменений
Рандомайзер уже ролит между двумя одинаковыми боксами. На практике приводило к засилию голосования в прайм, где игроки будут или играть оба вечерних динамика боксом, или оба экстендеда перед динамиком. 

Это не очень хорошо сказывалось на разнообразие.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
config: Рандом бокс стейшн не может выпасть более одного раунда подряд.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения баланса**
  * Для режима `boxstation_variants_rand` максимальное количество сыгранных раундов уменьшено с 2 до 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->