### PR TITLE
[TEST MERGE] Фикс add/remove mentor

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3049,16 +3049,16 @@
 	var/client/C = GLOB.directory[ckey]
 	if(C)
 		if(check_rights_for(C, R_ADMIN,0))
-			to_chat(usr, "<span class='danger'>The client chosen is an admin! Cannot mentorize.</span>")
+			to_chat(usr, span_danger("Выбранный клиент является администратором. Нельзя назначить его ментором."))
 			return
 	if(GLOB.mentor_datums[ckey])
-		to_chat(usr, "<span class='danger'>[ckey] is already a mentor.</span>")
+		to_chat(usr, span_danger("[ckey] уже является ментором."))
 		return
 	if(!SSplayer_ranks.add_player_to_group(usr.client, ckey, "mentor"))
 		return
-	message_admins("[key_name_admin(usr)] has granted mentor status to [ckey].")
-	log_admin_private("[key_name(usr)] has granted mentor status to [ckey].")
-	to_chat(usr, "<span class='adminnotice'>New mentor added.</span>")
+	message_admins("[key_name_admin(usr)] выдал [ckey] права ментора.")
+	log_admin_private("[key_name(usr)] выдал [ckey] права ментора.")
+	to_chat(usr, span_adminnotice("Права ментора выданы."))
 
 /datum/admins/proc/removeMentor(ckey)
 	if(!usr.client)
@@ -3071,13 +3071,13 @@
 	var/client/C = GLOB.directory[ckey]
 	if(C)
 		if(check_rights_for(C, R_ADMIN,0))
-			to_chat(usr, "<span class='danger'>The client chosen is an admin, not a mentor! Cannot de-mentorize.</span>")
+			to_chat(usr, span_danger("Выбранный клиент является администратором, а не ментором. Нельзя снять с него права ментора."))
 			return
 	if(!GLOB.mentor_datums[ckey])
-		to_chat(usr, "<span class='danger'>[ckey] is not a mentor.</span>")
+		to_chat(usr, span_danger("[ckey] не является ментором."))
 		return
 	if(!SSplayer_ranks.remove_player_from_group(usr.client, ckey, "mentor"))
 		return
-	message_admins("[key_name_admin(usr)] has revoked mentor status from [ckey].")
-	log_admin_private("[key_name(usr)] has revoked mentor status from [ckey].")
-	to_chat(usr, "<span class='adminnotice'>Mentor removed.</span>")
+	message_admins("[key_name_admin(usr)] снял с [ckey] права ментора.")
+	log_admin_private("[key_name(usr)] снял с [ckey] права ментора.")
+	to_chat(usr, span_adminnotice("Права ментора сняты."))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3043,6 +3043,7 @@
 		return
 	if (!check_rights(0))
 		return
+	ckey = ckey(ckey)
 	if(!ckey)
 		return
 	var/client/C = GLOB.directory[ckey]
@@ -3050,32 +3051,13 @@
 		if(check_rights_for(C, R_ADMIN,0))
 			to_chat(usr, "<span class='danger'>The client chosen is an admin! Cannot mentorize.</span>")
 			return
-	if(SSdbcore.Connect())
-		var/datum/db_query/query_get_mentor = SSdbcore.NewQuery(
-			"SELECT id FROM [format_table_name("mentor")] WHERE ckey = :ckey",
-			list("ckey" = ckey)
-		)
-		if(!query_get_mentor.warn_execute())
-			return
-		if(query_get_mentor.NextRow())
-			to_chat(usr, "<span class='danger'>[ckey] is already a mentor.</span>")
-			return
-		var/datum/db_query/query_add_mentor = SSdbcore.NewQuery(
-			"INSERT INTO [format_table_name("mentor")] (id, ckey) VALUES (:id, :ckey)",
-			list("id" = null, "ckey" = ckey)
-		)
-		if(!query_add_mentor.warn_execute())
-			return
-		var/datum/db_query/query_add_admin_log = SSdbcore.NewQuery({"
-			INSERT INTO [format_table_name("admin_log")] (datetime, round_id, adminckey, adminip, operation, target, log)
-			VALUES (:time, :round_id, :adminckey, INET_ATON(:adminip), 'add mentor', :mentor_ckey, CONCAT('Admin removed: ', :mentor_ckey))
-			"}, list("time" = SQLtime(), "round_id" = "[GLOB.round_id]", "adminckey" = usr.ckey, "adminip" = usr.client.address, "mentor_ckey" = ckey)
-		)
-		if(!query_add_admin_log.warn_execute())
-			return
-	else
-		to_chat(usr, "<span class='danger'>Failed to establish database connection. The changes will last only for the current round.</span>")
-	new /datum/mentors(ckey)
+	if(GLOB.mentor_datums[ckey])
+		to_chat(usr, "<span class='danger'>[ckey] is already a mentor.</span>")
+		return
+	if(!SSplayer_ranks.add_player_to_group(usr.client, ckey, "mentor"))
+		return
+	message_admins("[key_name_admin(usr)] has granted mentor status to [ckey].")
+	log_admin_private("[key_name(usr)] has granted mentor status to [ckey].")
 	to_chat(usr, "<span class='adminnotice'>New mentor added.</span>")
 
 /datum/admins/proc/removeMentor(ckey)
@@ -3083,6 +3065,7 @@
 		return
 	if (!check_rights(0))
 		return
+	ckey = ckey(ckey)
 	if(!ckey)
 		return
 	var/client/C = GLOB.directory[ckey]
@@ -3090,16 +3073,11 @@
 		if(check_rights_for(C, R_ADMIN,0))
 			to_chat(usr, "<span class='danger'>The client chosen is an admin, not a mentor! Cannot de-mentorize.</span>")
 			return
-		C.remove_mentor_verbs()
-		C.mentor_datum = null
-		GLOB.mentors -= C
-	if(SSdbcore.Connect())
-		var/datum/db_query/query_remove_mentor = SSdbcore.NewQuery("DELETE FROM [format_table_name("mentor")] WHERE ckey = '[ckey]'")
-		if(!query_remove_mentor.warn_execute())
-			return
-		var/datum/db_query/query_add_admin_log = SSdbcore.NewQuery("INSERT INTO [format_table_name("admin_log")] (`id` ,`datetime` ,`adminckey` ,`adminip` ,`log` ) VALUES (NULL , NOW( ) , '[usr.ckey]', '[usr.client.address]', 'Removed mentor [ckey]');")
-		if(!query_add_admin_log.warn_execute())
-			return
-	else
-		to_chat(usr, "<span class='danger'>Failed to establish database connection. The changes will last only for the current round.</span>")
+	if(!GLOB.mentor_datums[ckey])
+		to_chat(usr, "<span class='danger'>[ckey] is not a mentor.</span>")
+		return
+	if(!SSplayer_ranks.remove_player_from_group(usr.client, ckey, "mentor"))
+		return
+	message_admins("[key_name_admin(usr)] has revoked mentor status from [ckey].")
+	log_admin_private("[key_name(usr)] has revoked mentor status from [ckey].")
 	to_chat(usr, "<span class='adminnotice'>Mentor removed.</span>")


### PR DESCRIPTION
# Описание
- Переход с легаси `mentors.txt` SQL режима записи менторов на подсистемный `SSplayer_ranks` в отношении выдачи менторки.
- Система сначала фиксирует игрока как ментора, только затем сохраняет его в памяти.

## Причина изменений
Игра пытается использовать легаси SQL с txt-шником для записи менторсписка, ввиду чего возможно непредсказуемое поведение, если на каком-то из этапов сервер хрюкнет. 

У одного из менторов постоянно выдавалась ошибка `A SQL error occurred during this operation, check the server logs` на попытку снять менторку, причём она снималась; попытка выдать снова давала эту же ошибку и ошибку, что игрок уже является ментором после этого.

Эта порнография должна будет кончиться.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
admin: Фикс выдачи/отнятия менторских прав: переход с SQL-системы на SSplayer_ranks для хранения менторки в памяти.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Управление статусом наставника переведено на централизованный механизм групп.
  * Добавлены проверки текущего статуса наставника перед изменением.
  * Администраторы получают уведомления об успешном назначении или снятии статуса.
  * Добавлено приватное логирование операций с наставниками.
  * Перед проверками автоматически нормализуется идентификатор игрока.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->